### PR TITLE
Fix: leaks and semantics, testing for memory leaks

### DIFF
--- a/include/stringzilla/stringzilla.h
+++ b/include/stringzilla/stringzilla.h
@@ -2123,27 +2123,26 @@ SZ_PUBLIC void sz_string_init(sz_string_t *string) {
     string->u64s[3] = 0;
 }
 
-SZ_PUBLIC sz_bool_t sz_string_init_from(sz_string_t *string, sz_cptr_t added_start, sz_size_t added_length,
+SZ_PUBLIC sz_bool_t sz_string_init_from(sz_string_t *string, sz_cptr_t start, sz_size_t length,
                                         sz_memory_allocator_t *allocator) {
-
+    size_t space_needed = length + 1; // space for trailing \0
     SZ_ASSERT(string && allocator, "String and allocator can't be NULL.");
     // If we are lucky, no memory allocations will be needed.
-    if (added_length + 1 <= sz_string_stack_space) {
+    if (space_needed <= sz_string_stack_space) {
         string->on_stack.start = &string->on_stack.chars[0];
-        sz_copy(string->on_stack.start, added_start, added_length);
-        string->on_stack.start[added_length] = 0;
-        string->on_stack.length = added_length;
-        return sz_true_k;
+        string->on_stack.length = length;
     }
-    // If we are not lucky, we need to allocate memory.
-    sz_ptr_t new_start = (sz_ptr_t)allocator->allocate(added_length + 1, allocator->handle);
-    if (!new_start) return sz_false_k;
-
+    else {
+        // If we are not lucky, we need to allocate memory.
+        string->on_heap.start = (sz_ptr_t)allocator->allocate(space_needed, allocator->handle);
+        if (!string->on_heap.start) return sz_false_k;
+        string->on_heap.length = length;
+        string->on_heap.space = space_needed;
+    }
+    SZ_ASSERT(&string->on_stack.start == &string->on_heap.start, "Alignment confusion");
     // Copy into the new buffer.
-    string->on_heap.start = new_start;
-    sz_copy(string->on_heap.start, added_start, added_length);
-    string->on_heap.start[added_length] = 0;
-    string->on_heap.length = added_length;
+    sz_copy(string->on_heap.start, start, length);
+    string->on_heap.start[length] = 0;
     return sz_true_k;
 }
 

--- a/include/stringzilla/stringzilla.hpp
+++ b/include/stringzilla/stringzilla.hpp
@@ -1174,6 +1174,26 @@ class basic_string {
         SZ_ASSERT(*this == other, "");
     }
 
+  protected:
+    void move(basic_string &other) noexcept {
+        // We can't just assign the other string state, as its start address may be somewhere else on the stack.
+        sz_ptr_t string_start;
+        sz_size_t string_length;
+        sz_size_t string_space;
+        sz_bool_t string_is_on_heap;
+        sz_string_unpack(&other.string_, &string_start, &string_length, &string_space, &string_is_on_heap);
+
+        // Acquire the old string's value bitwise
+        *(&string_) = *(&other.string_);
+        if (!string_is_on_heap) {
+            // Reposition the string start pointer to the stack if it fits.
+            string_.on_stack.start = &string_.on_stack.chars[0];
+        }
+        sz_string_init(&other.string_); // Discard the other string.
+    }
+
+    bool is_sso() const { return string_.on_stack.start == &string_.on_stack.chars[0]; }
+
   public:
     // Member types
     using traits_type = std::char_traits<char>;
@@ -1210,32 +1230,16 @@ class basic_string {
         });
     }
 
-    basic_string(basic_string &&other) noexcept : string_(other.string_) {
-        // We can't just assign the other string state, as its start address may be somewhere else on the stack.
-        sz_ptr_t string_start;
-        sz_size_t string_length;
-        sz_size_t string_space;
-        sz_bool_t string_is_on_heap;
-        sz_string_unpack(&other.string_, &string_start, &string_length, &string_space, &string_is_on_heap);
-
-        // Reposition the string start pointer to the stack if it fits.
-        string_.on_stack.start = string_is_on_heap ? string_start : &string_.on_stack.chars[0];
-        // XXX: memory leak
-        sz_string_init(&other.string_); // Discard the other string.
-    }
+    basic_string(basic_string &&other) noexcept : string_(other.string_) { move(other); }
 
     basic_string &operator=(basic_string &&other) noexcept {
-        // We can't just assign the other string state, as its start address may be somewhere else on the stack.
-        sz_ptr_t string_start;
-        sz_size_t string_length;
-        sz_size_t string_space;
-        sz_bool_t string_is_on_heap;
-        sz_string_unpack(&other.string_, &string_start, &string_length, &string_space, &string_is_on_heap);
-
-        // Reposition the string start pointer to the stack if it fits.
-        string_.on_stack.start = string_is_on_heap ? string_start : &string_.on_stack.chars[0];
-        // XXX: memory leak
-        sz_string_init(&other.string_); // Discard the other string.
+        if (!is_sso()) {
+            with_alloc([&](alloc_t &alloc) {
+                sz_string_free(&string_, &alloc);
+                return sz_true_k;
+            });
+        }
+        move(other);
         return *this;
     }
 


### PR DESCRIPTION
Writing some leak-checking found a few bugs and correctness issues.

`sz_string_init_from` would sometimes leave a residue of noise in the `space` field of the new string. Lightly refactor to share some of the logic so it is easier to see that all four fields are set for both shapes of string.

The copied code in move constructor and assignment shared some issues: the target for the move didn't actually get initialized with the values of the source. For the case of move assignment where the target already held values, we need to release the associated memory.

I'm happy with the test code for this; while this is probably not a complete inventory of memory leaks, we have an easy way to add tests for new ones we encounter.