### PR TITLE
Fix: python slices of splits used incorrect offsets.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+build_debug/
 .DS_Store
 tmp/
 build_debug/
@@ -22,3 +23,4 @@ node_modules/
 leipzig1M.txt
 xlsum.csv
 enwik9
+.venv/*

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -43,7 +43,10 @@ def test_unit_contains():
 def test_unit_rich_comparisons():
     assert Str("aa") == "aa"
     assert Str("aa") < "b"
-    assert Str("abb")[1:] == "bb"
+    s2 = Str("abb")
+    assert s2[1:] == "bb"
+    assert s2[:-1] == "ab"
+    assert s2[-1:] == "b"
 
 
 def test_unit_buffer_protocol():
@@ -108,6 +111,28 @@ def test_unit_globals():
     assert sz.edit_distance("abababab", "aaaaaaaa", 2) == 2
     assert sz.edit_distance("abababab", "aaaaaaaa", bound=2) == 2
 
+def test_unit_len():
+    w = sz.Str("abcd")
+    assert 4 == len(w)
+
+def test_slice_of_split():
+    def impl(native_str):
+        native_split = native_str.split()
+        text = sz.Str(native_str)
+        split = text.split()
+        for split_idx in range(len(native_split)):
+            native_slice = native_split[split_idx:]
+            idx = split_idx
+            for word in split[split_idx:]:
+                assert str(word) == native_split[idx]
+                idx += 1
+    native_str = 'Weebles wobble before they fall down, don\'t they?'
+    impl(native_str)
+    # ~5GB to overflow 32-bit sizes
+    copies = int(len(native_str) / 5e9)
+    # Eek. Cover 64-bit indices
+    impl(native_str * copies) 
+ 
 
 def get_random_string(
     length: Optional[int] = None,


### PR DESCRIPTION
32-bit and 64-bit offset logic assumed a `Strs` produced from by slicing a previous `Strs` started at offset 0. `str.split().slice([1:])`, for instance, produced impossible end offsets. This was the cause of some SEGVs and negative-length Python string constructions.

Deduplicate the 32-bit and 64-bit logic, and fix the bug in the single copy of the logic.

Test for 32-bit and 64-bit indices. Previous version of `lib.c` caused this test to SEGV or produce runtime errors about constructing Python strings of negative length depending on memory conditions.