### PR TITLE
Big Endian support for SWAR backends

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,13 +90,19 @@ if(STRINGZILLA_INSTALL)
 endif()
 
 if(${STRINGZILLA_BUILD_TEST} OR ${STRINGZILLA_BUILD_BENCHMARK})
+  find_package(GTest REQUIRED)
+  include(GoogleTest)
+
   add_executable(stringzilla_test scripts/test.cpp)
+  add_executable(stringzilla_unittest scripts/ut_stringzilla.cpp)
+  target_link_libraries(stringzilla_unittest GTest::GTest GTest::Main)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
   set(CMAKE_CXX_FLAGS
       "${CMAKE_CXX_FLAGS} -O3 -flto -march=native -finline-functions -funroll-loops"
   )
 
   target_include_directories(stringzilla_test PRIVATE stringzilla)
+  target_include_directories(stringzilla_unittest PRIVATE stringzilla)
   set_target_properties(stringzilla_test PROPERTIES RUNTIME_OUTPUT_DIRECTORY
                                                     ${CMAKE_BINARY_DIR})
 
@@ -104,6 +110,7 @@ if(${STRINGZILLA_BUILD_TEST} OR ${STRINGZILLA_BUILD_BENCHMARK})
                                             3.13)
     include(CTest)
     enable_testing()
+    add_test(NAME stringzilla_unittest COMMAND stringzilla_unittest)
     add_test(NAME stringzilla_test COMMAND stringzilla_test)
   endif()
 endif()

--- a/scripts/test.cpp
+++ b/scripts/test.cpp
@@ -91,7 +91,11 @@ int hybrid_sort_c_compare_uint32_t(const void *a, const void *b) {
     return (int_a < int_b) ? -1 : (int_a > int_b);
 }
 
+#ifdef __APPLE__
 int hybrid_sort_c_compare_strings(void *arg, const void *a, const void *b) {
+#else
+int hybrid_sort_c_compare_strings(const void *arg, const void *a, void *b) {
+#endif
     sz_sequence_t *sequence = (sz_sequence_t *)arg;
     sz_size_t idx_a = *(sz_size_t *)a;
     sz_size_t idx_b = *(sz_size_t *)b;
@@ -123,8 +127,11 @@ sz_size_t hybrid_sort_c(sz_sequence_t *sequence) {
     }
 
     // Sort the full strings.
+#ifdef __APPLE__
     qsort_r(sequence->order, sequence->count, sizeof(sz_size_t), sequence, hybrid_sort_c_compare_strings);
-
+#else
+    qsort_r(sequence->order, sequence->count, sizeof(sz_size_t), hybrid_sort_c_compare_strings, sequence);
+#endif
     return sequence->count;
 }
 

--- a/scripts/ut_stringzilla.cpp
+++ b/scripts/ut_stringzilla.cpp
@@ -1,0 +1,93 @@
+#include <gtest/gtest.h>
+#include <string>
+#include <stringzilla.h>
+
+TEST(StringzillaSWAR, test_sz_count_char_swar) {
+    std::string haystack = "daddadddaddddaddddda";
+    std::string needle1 = "a";
+    std::string needle2 = "d";
+    ASSERT_EQ(sz_count_char_swar(haystack.data(), haystack.size(), needle1.data()), 5);
+    ASSERT_EQ(sz_count_char_swar(haystack.data(), haystack.size(), needle2.data()), 15);
+}
+
+TEST(StringzillaSWAR, test_sz_find_Xchar_swar) {
+    std::string haystack = "myneedleinhaystack";
+
+    ASSERT_EQ(sz_find_1char_swar(haystack.data(), haystack.size(), "m") - haystack.data(), 0);
+    ASSERT_EQ(sz_find_1char_swar(haystack.data(), haystack.size(), "y") - haystack.data(), 1);
+    ASSERT_EQ(sz_find_1char_swar(haystack.data(), haystack.size(), "n") - haystack.data(), 2);
+    ASSERT_EQ(sz_find_1char_swar(haystack.data(), haystack.size(), "e") - haystack.data(), 3);
+    ASSERT_EQ(sz_find_1char_swar(haystack.data(), haystack.size(), "d") - haystack.data(), 5);
+    ASSERT_EQ(sz_find_1char_swar(haystack.data(), haystack.size(), "l") - haystack.data(), 6);
+    ASSERT_EQ(sz_find_1char_swar(haystack.data(), haystack.size(), "i") - haystack.data(), 8);
+    ASSERT_EQ(sz_find_1char_swar(haystack.data(), haystack.size(), "h") - haystack.data(), 10);
+    ASSERT_EQ(sz_find_1char_swar(haystack.data(), haystack.size(), "k") - haystack.data(), 17);
+
+    ASSERT_EQ(sz_find_2char_swar(haystack.data(), haystack.size(), "my") - haystack.data(), 0);
+    ASSERT_EQ(sz_find_2char_swar(haystack.data(), haystack.size(), "yn") - haystack.data(), 1);
+    ASSERT_EQ(sz_find_2char_swar(haystack.data(), haystack.size(), "ne") - haystack.data(), 2);
+    ASSERT_EQ(sz_find_2char_swar(haystack.data(), haystack.size(), "ee") - haystack.data(), 3);
+    ASSERT_EQ(sz_find_2char_swar(haystack.data(), haystack.size(), "ed") - haystack.data(), 4);
+    ASSERT_EQ(sz_find_2char_swar(haystack.data(), haystack.size(), "dl") - haystack.data(), 5);
+    ASSERT_EQ(sz_find_2char_swar(haystack.data(), haystack.size(), "le") - haystack.data(), 6);
+    ASSERT_EQ(sz_find_2char_swar(haystack.data(), haystack.size(), "ei") - haystack.data(), 7);
+    ASSERT_EQ(sz_find_2char_swar(haystack.data(), haystack.size(), "in") - haystack.data(), 8);
+
+
+    ASSERT_EQ(sz_find_3char_swar(haystack.data(), haystack.size(), "myn") - haystack.data(), 0);
+    ASSERT_EQ(sz_find_3char_swar(haystack.data(), haystack.size(), "yne") - haystack.data(), 1);
+    ASSERT_EQ(sz_find_3char_swar(haystack.data(), haystack.size(), "nee") - haystack.data(), 2);
+    ASSERT_EQ(sz_find_3char_swar(haystack.data(), haystack.size(), "eed") - haystack.data(), 3);
+    ASSERT_EQ(sz_find_3char_swar(haystack.data(), haystack.size(), "edl") - haystack.data(), 4);
+    ASSERT_EQ(sz_find_3char_swar(haystack.data(), haystack.size(), "dle") - haystack.data(), 5);
+    ASSERT_EQ(sz_find_3char_swar(haystack.data(), haystack.size(), "lei") - haystack.data(), 6);
+    ASSERT_EQ(sz_find_3char_swar(haystack.data(), haystack.size(), "ein") - haystack.data(), 7);
+    ASSERT_EQ(sz_find_3char_swar(haystack.data(), haystack.size(), "inh") - haystack.data(), 8);
+
+    ASSERT_EQ(sz_find_4char_swar(haystack.data(), haystack.size(), "myne") - haystack.data(), 0);
+    ASSERT_EQ(sz_find_4char_swar(haystack.data(), haystack.size(), "ynee") - haystack.data(), 1);
+    ASSERT_EQ(sz_find_4char_swar(haystack.data(), haystack.size(), "need") - haystack.data(), 2);
+    ASSERT_EQ(sz_find_4char_swar(haystack.data(), haystack.size(), "eedl") - haystack.data(), 3);
+    ASSERT_EQ(sz_find_4char_swar(haystack.data(), haystack.size(), "edle") - haystack.data(), 4);
+    ASSERT_EQ(sz_find_4char_swar(haystack.data(), haystack.size(), "dlei") - haystack.data(), 5);
+    ASSERT_EQ(sz_find_4char_swar(haystack.data(), haystack.size(), "lein") - haystack.data(), 6);
+    ASSERT_EQ(sz_find_4char_swar(haystack.data(), haystack.size(), "einh") - haystack.data(), 7);
+    ASSERT_EQ(sz_find_4char_swar(haystack.data(), haystack.size(), "inha") - haystack.data(), 8);
+    ASSERT_EQ(sz_find_4char_swar(haystack.data(), haystack.size(), "nhay") - haystack.data(), 9);
+    ASSERT_EQ(sz_find_4char_swar(haystack.data(), haystack.size(), "hays") - haystack.data(), 10);
+    ASSERT_EQ(sz_find_4char_swar(haystack.data(), haystack.size(), "ayst") - haystack.data(), 11);
+    ASSERT_EQ(sz_find_4char_swar(haystack.data(), haystack.size(), "ysta") - haystack.data(), 12);
+    ASSERT_EQ(sz_find_4char_swar(haystack.data(), haystack.size(), "stac") - haystack.data(), 13);
+    ASSERT_EQ(sz_find_4char_swar(haystack.data(), haystack.size(), "tack") - haystack.data(), 14);
+}
+
+TEST(StringzillaSWAR, test_sz_rfind_1char_swar) {
+    std::string haystack = "myneedleinhaystack";
+
+    ASSERT_EQ(sz_rfind_1char_swar(haystack.data(), haystack.size(), "m") - haystack.data(), 0);
+    ASSERT_EQ(sz_rfind_1char_swar(haystack.data(), haystack.size(), "d") - haystack.data(), 5);
+    ASSERT_EQ(sz_rfind_1char_swar(haystack.data(), haystack.size(), "l") - haystack.data(), 6);
+    ASSERT_EQ(sz_rfind_1char_swar(haystack.data(), haystack.size(), "e") - haystack.data(), 7);
+    ASSERT_EQ(sz_rfind_1char_swar(haystack.data(), haystack.size(), "h") - haystack.data(), 10);
+    ASSERT_EQ(sz_rfind_1char_swar(haystack.data(), haystack.size(), "a") - haystack.data(), 15);
+
+    std::string alphabet = "abcdefghijklmnopqrstuvwxyz";
+
+    for (int i = 24; i < alphabet.size(); i++) {
+        std::string needle = std::string(1, alphabet[i]);
+        EXPECT_EQ(sz_rfind_1char_swar(alphabet.data(), alphabet.size(), needle.data()) - alphabet.data(), i);
+    }
+}
+
+TEST(StringzillaSWAR, test_sz_find_substring_swar) {
+    std::string haystack = "myneedleinhaystack";
+    std::string needle = "needle";
+    sz_string_start_t ptr = sz_find_substring_swar(haystack.data(), haystack.size(), needle.data(), needle.size());
+    ASSERT_TRUE(ptr);
+    ASSERT_EQ(std::string(ptr, 6), "needle");
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Hi! Noticed that there is no support for Big Endian, so decided to start working on it.
Currently I did:

- [x]  sz_find_1char_swar
- [x] sz_rfind_1char_swar
- [x] sz_find_2char_swar
- [x] sz_find_3char_swar
- [x] sz_find_4char_swar
- [x] sz_find_substring_swar

(also fixed a little bug in the little endian version of `sz_rfind_1char_swar`).

I also took a liberty of adding googletest dependency (of course I can remove it, I just prefer using it) 
and supporting linux version of qsort_r in the test.cpp.

Although I am using macOS, I was able to test on a big endian machine using QEMU and docker. So I think the next thing to do for this pull request will be adding a workflow with the similar setup (or maybe GitHub has BE machines, I don't know yet).

With all those `if (IS_LITTLE_ENDIAN)` code looks funky, I know. I will try to do something with it