### PR TITLE
Fix the CMake code of the project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.12)
+
 project(
   stringzilla
   VERSION 3.0.0
@@ -6,239 +7,56 @@ project(
   DESCRIPTION "SIMD-accelerated string search, sort, hashes, fingerprints, & edit distances"
   HOMEPAGE_URL "https://github.com/ashvardanian/stringzilla")
 
-set(CMAKE_C_STANDARD 99)
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_C_EXTENSIONS OFF)
-set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_COMPILE_WARNING_AS_ERROR)
-set(DEV_USER_NAME $ENV{USER})
-
-message(STATUS "C Compiler ID: ${CMAKE_C_COMPILER_ID}")
-message(STATUS "C Compiler Version: ${CMAKE_C_COMPILER_VERSION}")
-message(STATUS "C Compiler: ${CMAKE_C_COMPILER}")
-message(STATUS "C++ Compiler ID: ${CMAKE_CXX_COMPILER_ID}")
-message(STATUS "C++ Compiler Version: ${CMAKE_CXX_COMPILER_VERSION}")
-message(STATUS "C++ Compiler: ${CMAKE_CXX_COMPILER}")
-message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
-
-# Set a default build type to "Release" if none was specified
-if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-  message(STATUS "Setting build type to 'Release' as none was specified.")
-  set(CMAKE_BUILD_TYPE
-    Release
-    CACHE STRING "Choose the type of build." FORCE)
-  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release"
-    "MinSizeRel" "RelWithDebInfo")
-endif()
-
-# Determine if StringZilla is built as a subproject (using `add_subdirectory`)
-# or if it is the main project
-set(STRINGZILLA_IS_MAIN_PROJECT OFF)
-
+set(PROJECT_IS_TOP_LEVEL 0)
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
-  set(STRINGZILLA_IS_MAIN_PROJECT ON)
+  set(PROJECT_IS_TOP_LEVEL 1)
 endif()
 
-# Installation options
-option(STRINGZILLA_INSTALL "Install CMake targets" OFF)
-option(STRINGZILLA_BUILD_TEST "Compile a native unit test in C++"
-  ${STRINGZILLA_IS_MAIN_PROJECT})
-option(STRINGZILLA_BUILD_BENCHMARK "Compile a native benchmark in C++"
-  ${STRINGZILLA_IS_MAIN_PROJECT})
-option(STRINGZILLA_BUILD_SHARED "Compile a dynamic library" ${STRINGZILLA_IS_MAIN_PROJECT})
-set(STRINGZILLA_TARGET_ARCH
-  ""
-  CACHE STRING "Architecture to tell the compiler to optimize for (-march)")
+include(cmake/warning-guard.cmake)
 
-# Includes
-set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
-include(ExternalProject)
-include(CheckCSourceCompiles)
-
-# Allow CMake 3.13+ to override options when using FetchContent /
-# add_subdirectory
-if(POLICY CMP0077)
-  cmake_policy(SET CMP0077 NEW)
-endif()
-
-# Configuration
-include(GNUInstallDirs)
-set(STRINGZILLA_TARGET_NAME ${PROJECT_NAME})
-set(STRINGZILLA_INCLUDE_BUILD_DIR "${PROJECT_SOURCE_DIR}/include/")
-
-# Define our library
-add_library(${STRINGZILLA_TARGET_NAME} INTERFACE)
-add_library(${PROJECT_NAME}::${STRINGZILLA_TARGET_NAME} ALIAS ${STRINGZILLA_TARGET_NAME})
-
+add_library(stringzilla INTERFACE)
+add_library(stringzilla::stringzilla ALIAS stringzilla)
 target_include_directories(
-  ${STRINGZILLA_TARGET_NAME}
-  INTERFACE $<BUILD_INTERFACE:${STRINGZILLA_INCLUDE_BUILD_DIR}>
-  $<INSTALL_INTERFACE:include>)
+  stringzilla ${warning_guard}
+  INTERFACE "\$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>")
+target_compile_features(stringzilla INTERFACE cxx_std_11)
 
-if(STRINGZILLA_INSTALL)
-  install(
-    TARGETS ${STRINGZILLA_TARGET_NAME}
-    EXPORT ${STRINGZILLA_TARGETS_EXPORT_NAME}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    INCLUDES
-    DESTINATION ${STRINGZILLA_INCLUDE_INSTALL_DIR})
-  install(DIRECTORY ${STRINGZILLA_INCLUDE_BUILD_DIR}
-    DESTINATION ${STRINGZILLA_INCLUDE_INSTALL_DIR})
+add_library(stringzilla_c SHARED c/lib.c)
+add_library(stringzilla::stringzilla_c ALIAS stringzilla_c)
+set_property(TARGET stringzilla_c PROPERTY OUTPUT_NAME stringzilla)
+target_include_directories(
+  stringzilla_c ${warning_guard}
+  PUBLIC "\$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>")
+target_compile_features(stringzilla_c PUBLIC c_std_99)
+
+add_library(stringzillite SHARED c/lib.c)
+add_library(stringzilla::stringzillite ALIAS stringzillite)
+target_compile_definitions(stringzillite PRIVATE SZ_AVOID_LIBC=1)
+target_include_directories(
+  stringzillite ${warning_guard}
+  PUBLIC "\$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>")
+target_compile_features(stringzillite PUBLIC c_std_99)
+
+set_target_properties(
+  stringzillite stringzilla_c PROPERTIES
+  C_VISIBILITY_PRESET hidden
+  VERSION "${PROJECT_VERSION}"
+  SOVERSION 1)
+
+if(MSVC)
+  target_compile_definitions(stringzillite PRIVATE "__SIZE_TYPE__=unsigned long long")
 endif()
 
-if(${CMAKE_VERSION} VERSION_EQUAL 3.13 OR ${CMAKE_VERSION} VERSION_GREATER 3.13)
-  include(CTest)
-  enable_testing()
+if(NOT CMAKE_SKIP_INSTALL_RULES)
+  include(cmake/install-rules.cmake)
 endif()
 
-# Function to set compiler-specific flags
-function(set_compiler_flags target cpp_standard target_arch)
-  target_include_directories(${target} PRIVATE scripts)
-  target_link_libraries(${target} PRIVATE ${STRINGZILLA_TARGET_NAME})
-
-  # Set output directory for single-configuration generators (like Make)
-  set_target_properties(${target} PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/$<0:>
-  )
-
-  # Set output directory for multi-configuration generators (like Visual Studio)
-  foreach(config IN LISTS CMAKE_CONFIGURATION_TYPES)
-    string(TOUPPER ${config} config_upper)
-    set_target_properties(${target} PROPERTIES
-      RUNTIME_OUTPUT_DIRECTORY_${config_upper} ${CMAKE_BINARY_DIR}/$<0:>
-    )
-  endforeach()
-
-  # Set the C++ standard
-  if(NOT ${cpp_standard} STREQUAL "")
-    # Use the /Zc:__cplusplus flag to correctly define the __cplusplus macro in MSVC
-    set(CXX_STANDARD_MSVC "/std:c++${cpp_standard};/Zc:__cplusplus")
-    set(CXX_STANDARD_GNU "-std=c++${cpp_standard}")
-    target_compile_options(${target} PRIVATE
-      "$<$<CXX_COMPILER_ID:MSVC>:${CXX_STANDARD_MSVC}>"
-      "$<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:${CXX_STANDARD_GNU}>"
-    )
-  endif()
-
-  # Maximum warnings level & warnings as error
-  target_compile_options(
-    ${target}
-    PRIVATE
-    "$<$<CXX_COMPILER_ID:MSVC>:/STOP>" # For MSVC, /WX would have been sufficient
-    "$<$<CXX_COMPILER_ID:GNU>:-Wall;-Wextra;-pedantic;-Werror;-Wfatal-errors;-Wno-unknown-pragmas;-Wno-cast-function-type;-Wno-unused-function>"
-    "$<$<CXX_COMPILER_ID:Clang>:-Wall;-Wextra;-pedantic;-Werror;-Wfatal-errors;-Wno-unknown-pragmas>"
-    "$<$<CXX_COMPILER_ID:AppleClang>:-Wall;-Wextra;-pedantic;-Werror;-Wfatal-errors;-Wno-unknown-pragmas>"
-  )
-
-  # Set optimization options for different compilers differently
-  target_compile_options(
-    ${target}
-    PRIVATE
-    "$<$<AND:$<CXX_COMPILER_ID:GNU>,$<OR:$<CONFIG:Release>,$<CONFIG:RelWithDebInfo>>>:-O3>"
-    "$<$<AND:$<CXX_COMPILER_ID:GNU>,$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>>:-g>"
-    "$<$<AND:$<CXX_COMPILER_ID:Clang>,$<OR:$<CONFIG:Release>,$<CONFIG:RelWithDebInfo>>>:-O3>"
-    "$<$<AND:$<CXX_COMPILER_ID:Clang>,$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>>:-g>"
-    "$<$<AND:$<CXX_COMPILER_ID:MSVC>,$<CONFIG:Release>>:/O2>"
-    "$<$<AND:$<CXX_COMPILER_ID:MSVC>,$<OR:$<CONFIG:Release>,$<CONFIG:RelWithDebInfo>>>:/O2>"
-    "$<$<AND:$<CXX_COMPILER_ID:MSVC>,$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>>:/Zi>"
-  )
-
-  # Enable Position Independent Code
-  target_compile_options(${target} PRIVATE "$<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-fPIC>")
-  target_link_options(${target} PRIVATE "$<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-fPIC>")
-
-  # Check for ${target_arch} and set it or use "march=native" if not defined
-  if("${target_arch}" STREQUAL "")
-    # MSVC does not have a direct equivalent to -march=native
-    target_compile_options(
-      ${target} PRIVATE
-      "$<$<AND:$<CXX_COMPILER_ID:GNU>,$<NOT:$<CXX_COMPILER_ID:AppleClang>>>:-march=native>"
-      "$<$<CXX_COMPILER_ID:MSVC>:/arch:AVX2>")
-  else()
-    target_compile_options(
-      ${target}
-      PRIVATE
-      "$<$<AND:$<CXX_COMPILER_ID:GNU>,$<NOT:$<CXX_COMPILER_ID:AppleClang>>>:-march=${target_arch}>"
-      "$<$<CXX_COMPILER_ID:MSVC>:/arch:${target_arch}>")
-  endif()
-
-  # Sanitizer options for Debug mode
-  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-    target_compile_options(
-      ${target}
-      PRIVATE
-      "$<$<CXX_COMPILER_ID:GNU,Clang>:-fsanitize=address;-fsanitize=leak>"
-      "$<$<CXX_COMPILER_ID:MSVC>:/fsanitize=address>")
-
-    target_link_options(
-      ${target}
-      PRIVATE
-      "$<$<CXX_COMPILER_ID:GNU,Clang>:-fsanitize=address;-fsanitize=leak>"
-      "$<$<CXX_COMPILER_ID:MSVC>:/fsanitize=address>")
-
-    # Define SZ_DEBUG macro based on build configuration
-    target_compile_definitions(
-      ${target}
-      PRIVATE
-      "$<$<CONFIG:Debug>:SZ_DEBUG=1>"
-      "$<$<NOT:$<CONFIG:Debug>>:SZ_DEBUG=0>"
-    )
-  endif()
-endfunction()
-
-function(define_launcher exec_name source cpp_standard target_arch)
-  add_executable(${exec_name} ${source})
-  set_compiler_flags(${exec_name} ${cpp_standard} "${target_arch}")
-  add_test(NAME ${exec_name} COMMAND ${exec_name})
-endfunction()
-
-if(${STRINGZILLA_BUILD_BENCHMARK})
-  define_launcher(stringzilla_bench_search scripts/bench_search.cpp 17 "${STRINGZILLA_TARGET_ARCH}")
-  define_launcher(stringzilla_bench_similarity scripts/bench_similarity.cpp 17 "${STRINGZILLA_TARGET_ARCH}")
-  define_launcher(stringzilla_bench_sort scripts/bench_sort.cpp 17 "${STRINGZILLA_TARGET_ARCH}")
-  define_launcher(stringzilla_bench_token scripts/bench_token.cpp 17 "${STRINGZILLA_TARGET_ARCH}")
-  define_launcher(stringzilla_bench_container scripts/bench_container.cpp 17 "${STRINGZILLA_TARGET_ARCH}")
+if(NOT stringzilla_DEVELOPER_MODE)
+  return()
+elseif(NOT PROJECT_IS_TOP_LEVEL)
+  message(
+    AUTHOR_WARNING
+    "Developer mode is intended for developers of stringzilla")
 endif()
 
-if(${STRINGZILLA_BUILD_TEST})
-  # Make sure that the compilation passes for different C++ standards
-  # ! Keep in mind, MSVC only supports C++11 and newer.
-  define_launcher(stringzilla_test_cpp11 scripts/test.cpp 11 "${STRINGZILLA_TARGET_ARCH}")
-  define_launcher(stringzilla_test_cpp14 scripts/test.cpp 14 "${STRINGZILLA_TARGET_ARCH}")
-  define_launcher(stringzilla_test_cpp17 scripts/test.cpp 17 "${STRINGZILLA_TARGET_ARCH}")
-  define_launcher(stringzilla_test_cpp20 scripts/test.cpp 20 "${STRINGZILLA_TARGET_ARCH}")
-
-  # Check system architecture to avoid complex cross-compilation workflows, but
-  # compile multiple backends: disabling all SIMD, enabling only AVX2, only AVX-512, only Arm Neon.
-  if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64|amd64")
-    # x86 specific backends
-    define_launcher(stringzilla_test_cpp20_x86_serial scripts/test.cpp 20 "ivybridge")
-    define_launcher(stringzilla_test_cpp20_x86_avx2 scripts/test.cpp 20 "haswell")
-    define_launcher(stringzilla_test_cpp20_x86_avx512 scripts/test.cpp 20 "sapphirerapids")
-  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "arm|ARM|aarch64|AARCH64")
-    # ARM specific backends
-    define_launcher(stringzilla_test_cpp20_arm_serial scripts/test.cpp 20 "armv8-a")
-    define_launcher(stringzilla_test_cpp20_arm_neon scripts/test.cpp 20 "armv8-a+simd")
-  endif()
-endif()
-
-if(${STRINGZILLA_BUILD_SHARED})
-  add_library(stringzilla_shared SHARED c/lib.c)
-  set_compiler_flags(stringzilla_shared "" "${STRINGZILLA_TARGET_ARCH}")
-  set_target_properties(stringzilla_shared PROPERTIES
-    VERSION ${PROJECT_VERSION}
-    SOVERSION 1
-    POSITION_INDEPENDENT_CODE ON
-    PUBLIC_HEADER include/stringzilla/stringzilla.h)
-
-  # Try compiling a version without linking the LibC
-  add_library(stringzillite SHARED c/lib.c)
-  set_compiler_flags(stringzillite "" "${STRINGZILLA_TARGET_ARCH}")
-  target_compile_definitions(stringzillite PRIVATE "SZ_AVOID_LIBC=1")
-  set_target_properties(stringzillite PROPERTIES
-    VERSION ${PROJECT_VERSION}
-    SOVERSION 1
-    POSITION_INDEPENDENT_CODE ON
-    PUBLIC_HEADER include/stringzilla/stringzilla.h)
-endif()
+include(cmake/dev.cmake)

--- a/cmake/dev.cmake
+++ b/cmake/dev.cmake
@@ -1,0 +1,55 @@
+function(sz_test target)
+  add_executable("${target}" ${ARGN})
+  target_link_libraries("${target}" PRIVATE stringzilla::stringzilla)
+  add_test(NAME "${target}" COMMAND "${target}")
+endfunction()
+
+function(sz_simd_test arch target)
+  sz_test("${target}" ${ARGN})
+  target_compile_options("${target}" PRIVATE "-march=${arch}")
+  set_target_properties(
+    "${target}" PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED 1)
+  set_property(TEST "${target}" PROPERTY LABELS simd std20)
+endfunction()
+
+include(CTest)
+if(BUILD_TESTING)
+  foreach(std 11 14 17 20)
+    sz_test("stringzilla_test_cpp${std}" scripts/test.cpp)
+    set_target_properties(
+      "stringzilla_test_cpp${std}" PROPERTIES
+      CXX_STANDARD "${std}"
+      CXX_STANDARD_REQUIRED 1)
+    set_property(TEST "stringzilla_test_cpp${std}" PROPERTY LABELS normal "std${std}")
+  endforeach()
+
+  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang\$|^GNU\$")
+    # Check system architecture to avoid complex cross-compilation workflows, but
+    # compile multiple backends: disabling all SIMD, enabling only AVX2, only AVX-512, only Arm Neon.
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64|amd64")
+      # x86 specific backends
+      sz_simd_test(ivybridge stringzilla_test_cpp20_x86_serial scripts/test.cpp)
+      sz_simd_test(haswell stringzilla_test_cpp20_x86_avx2 scripts/test.cpp)
+      sz_simd_test(sapphirerapids stringzilla_test_cpp20_x86_avx512 scripts/test.cpp)
+    elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "arm|ARM|aarch64|AARCH64")
+      # ARM specific backends
+      sz_simd_test(armv8-a stringzilla_test_cpp20_arm_serial scripts/test.cpp)
+      sz_simd_test(armv8-a+simd stringzilla_test_cpp20_arm_neon scripts/test.cpp)
+    endif()
+  endif()
+endif()
+
+option(BUILD_BENCHMARK "Compile a native benchmark in C++" ON)
+if(BUILD_BENCHMARK)
+  foreach(type search similarity sort token container)
+    sz_test("stringzilla_bench_${type}" "scripts/bench_${type}.cpp")
+    set_target_properties(
+      "stringzilla_bench_${type}" PROPERTIES
+      CXX_STANDARD 20
+      CXX_STANDARD_REQUIRED 1)
+    set_property(TEST "stringzilla_bench_${type}" PROPERTY LABELS bench std20)
+    target_include_directories("stringzilla_bench_${type}" PRIVATE scripts)
+  endforeach()
+endif()

--- a/cmake/install-config.cmake
+++ b/cmake/install-config.cmake
@@ -1,0 +1,1 @@
+include("${CMAKE_CURRENT_LIST_DIR}/stringzillaTargets.cmake")

--- a/cmake/install-rules.cmake
+++ b/cmake/install-rules.cmake
@@ -1,0 +1,53 @@
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
+
+install(
+  DIRECTORY include/
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+  COMPONENT stringzilla_Development)
+
+install(
+  TARGETS stringzilla stringzilla_c stringzillite
+  EXPORT stringzillaTargets
+  RUNTIME
+  DESTINATION "${CMAKE_INSTALL_BINDIR}"
+  COMPONENT stringzilla_Runtime
+  LIBRARY
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  COMPONENT stringzilla_Runtime
+  NAMELINK_COMPONENT stringzilla_Development
+  ARCHIVE
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  COMPONENT stringzilla_Development
+  INCLUDES
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+
+write_basic_package_version_file(
+  stringzillaConfigVersion.cmake
+  COMPATIBILITY SameMajorVersion)
+
+set(
+  stringzilla_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/stringzilla"
+  CACHE STRING "CMake package config location relative to the install prefix")
+mark_as_advanced(stringzilla_INSTALL_CMAKEDIR)
+
+install(
+  FILES cmake/install-config.cmake
+  DESTINATION "${stringzilla_INSTALL_CMAKEDIR}"
+  RENAME stringzillaConfig.cmake
+  COMPONENT stringzilla_Development)
+
+install(
+  FILES "${PROJECT_BINARY_DIR}/stringzillaConfigVersion.cmake"
+  DESTINATION "${stringzilla_INSTALL_CMAKEDIR}"
+  COMPONENT stringzilla_Development)
+
+install(
+  EXPORT stringzillaTargets
+  NAMESPACE stringzilla::
+  DESTINATION "${stringzilla_INSTALL_CMAKEDIR}"
+  COMPONENT stringzilla_Development)
+
+if(PROJECT_IS_TOP_LEVEL)
+  include(CPack)
+endif()

--- a/cmake/warning-guard.cmake
+++ b/cmake/warning-guard.cmake
@@ -1,0 +1,11 @@
+set(warning_guard "")
+if(NOT PROJECT_IS_TOP_LEVEL)
+  option(
+    stringzilla_INCLUDES_WITH_SYSTEM
+    "Use SYSTEM modifier for stringzilla's includes, disabling warnings"
+    ON)
+  mark_as_advanced(stringzilla_INCLUDES_WITH_SYSTEM)
+  if(stringzilla_INCLUDES_WITH_SYSTEM)
+    set(warning_guard SYSTEM)
+  endif()
+endif()


### PR DESCRIPTION
Some things this fixes:

* Never supported CMake 3.1.
* Did not support clients using CMake.
* Polluted dependees consuming it via vendoring (i.e. `add_subdirectory`).
* Too many pointless genexes. Put the flags in a preset and not the project code.  
* The project was hopelessly broken for MSVC, now the actual library at least builds and can be installed, although `stringzillite` seems very suspect still. The developer targets are still very much broken.  
* Setting `CMAKE_*` variables, which is verboten.
* Pointless noise from those `message` calls.
* Not using/supporting CMake provided variables like `BUILD_TESTING` and `CMAKE_SKIP_INSTALL_RULES`.
