### PR TITLE
feat: port randomize and sz_generate to Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "stringzilla"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "cc",
 ]


### PR DESCRIPTION
# Context
Tries to bring the `sz_generate` and `randomize` to Rust

## Design of the function implementation
As seen on the toml, you only rely on `core::ffi` lib, with no allocation, as well as `no_std`

### Constraints encountered
On both your C and CPP implementations, you have two definitions:
- one generating in-place
- one generating and returning a basic_string

This draft is only based on the in-place implementaiton as it allows me to avoid the allocation question: as you are in`no_std`, `std::Vec` is not possible, so the allocation of the returned string / vec<u8> would rely on the `alloc` crate ? Do you have any opinion on that, or did I miss something ?

Also, I encountered a mutability issue around the traits, to ship the PR as a draft, I rely on this MutableStringZilla trait, but the aim would be to unify them. I tried, but some of the distance functions fail, need to dig a bit more.

My tests currently rely on a Vec, not a String, as the String doesn't comply with the `AsMut<N>`. In this case, to test the string, we would need to rely on the implementation returning a string or a vec

## Current issue

I am having an issue on the linker, which doesn't find the
```
ld: Undefined symbols:
            _sz_generate, referenced from:
```

I believe this is due to the fact that `sz_generate` is solely implemented in the `.h`, making the FFI not find the function implementation ? I've been blocked tonight on it, any guidance would be helpful 🙏 Instead of relying just on sz_generate, shall I rely on the underlying functions and implement it directly in Rust ?

Nonetheless, please tell me if I am totally not getting it ? 🙏 The aim is to iterate on the PR until the implementation 
