### PR TITLE
Make: Upgrade PyPy images for GCC12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ build-verbosity = 0
 # https://cibuildwheel.readthedocs.io/en/stable/options/#archs
 #
 # Important to note, not all those paltforms have recent images.
-# The `manylinux_2_28` seems to be missing for `s390x`, `i686`, and `ppc64le`.
+# The `manylinux_2_28` seems to be missing for `i686`.
 # The `i686` is 32-bit x86, and `x86_64` is 64-bit x86.
 archs = ["all"]
 
@@ -49,8 +49,13 @@ repair-wheel-command = "auditwheel repair --lib-sdir . -w {dest_dir} {wheel}"
 # - for `musllinux`: https://quay.io/search?q=musllinux
 manylinux-x86_64-image = "manylinux_2_28"
 manylinux-aarch64-image = "manylinux_2_28"
+manylinux-s390x-image = "manylinux_2_28"
+manylinux-ppc64le-image = "manylinux_2_28"
 musllinux-x86_64-image = "musllinux_1_2"
 musllinux-aarch64-image = "musllinux_1_2"
+musllinux-s390x-image = "musllinux_1_2"
+musllinux-ppc64le-image = "musllinux_1_2"
+musllinux-i686-image = "musllinux_1_2"
 
 # On CentOS we have to use `yum`.
 # The healthy version would be: `apt-get update && apt-get install -y libc6-dev wget python3-dev`.


### PR DESCRIPTION
At this point, the older images [crush the CI](https://github.com/ashvardanian/StringZilla/actions/runs/8120941587/job/22205963188), when running `yum update` inside the image:

```sh
      + /opt/python/cp38-cp38/bin/python -c 'import sys, json, os; json.dump(os.environ.copy(), sys.stdout)'
      + sh -c 'yum update -y && yum install -y glibc-devel wget python3-devel'
  Loaded plugins: fastestmirror, ovl
  Determining fastest mirrors
  Could not retrieve mirrorlist http://mirrors.sinenomine.net/clefos?releasever=7&arch=s390x&repo=sclo&sub=rh error was
  12: Timeout on http://mirrors.sinenomine.net/clefos?releasever=7&arch=s390x&repo=sclo&sub=rh: (28, 'Connection timed out after 30001 milliseconds')
  
  
   One of the configured repositories failed (Unknown),
   and yum doesn't have enough cached data to continue. At this point the only
   safe thing yum can do is fail. There are a few ways to work "fix" this:
  
       1. Contact the upstream for the repository and get them to fix the problem.
  
       2. Reconfigure the baseurl/etc. for the repository, to point to a working
          upstream. This is most often useful if you are using a newer
          distribution release than is supported by the repository (and the
          packages for the previous distribution release still work).
  
       3. Run the command with the repository temporarily disabled
              yum --disablerepo=<repoid> ...
  
       4. Disable the repository permanently, so yum won't use it by default. Yum
          will then just ignore the repository until you permanently enable it
          again or use --enablerepo for temporary usage:
  
              yum-config-manager --disable <repoid>
          or
              subscription-manager repos --disable=<repoid>
  
       5. Configure the failing repository to be skipped, if it is unavailable.
          Note that yum will try to contact the repo. when it runs most commands,
          so will have to try and fail each time (and thus. yum will be be much
          slower). If it is a very temporary problem though, this is often a nice
          compromise:
  
              yum-config-manager --save --setopt=<repoid>.skip_if_unavailable=true
  
  Cannot find a valid baseurl for repo: clefos-rh/s390x
  Error: Command ['sh', '-c', 'yum update -y && yum install -y glibc-devel wget python3-devel'] failed with code 1. 
```

The newer ones replace CentOS with AlmaLinux, and bring GCC 12.