### PR TITLE
Added MSVC build to workflow & Fixed MSVC build issues

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -265,7 +265,7 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@v1
 
       - name: Build C/C++
-      - run: |
+        run: |
           cmake -GNinja -B build_artifacts ^
             -DCMAKE_BUILD_TYPE=RelWithDebInfo ^
             -DCMAKE_EXPORT_COMPILE_COMMANDS=1 ^

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -42,7 +42,7 @@ jobs:
             -DSTRINGZILLA_BUILD_BENCHMARK=1 \
             -DSTRINGZILLA_BUILD_TEST=1
 
-          cmake --build build_artifacts --config RelWithDebInfo > build_artifacts/logs.txt 2>&1 || {
+          cmake --build build_artifacts --config RelWithDebInfo > build_artifacts\logs.txt 2>&1 || {
             echo "Compilation failed. Here are the logs:"
             cat build_artifacts/logs.txt
             echo "The original compilation commands:"
@@ -262,7 +262,42 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ilammy/msvc-dev-cmd@v1
 
+      - name: Build C/C++
+      - run: |
+          cmake -GNinja -B build_artifacts ^
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo ^
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=1 ^
+            -DSTRINGZILLA_BUILD_BENCHMARK=1 ^
+            -DSTRINGZILLA_BUILD_TEST=1
+          
+          cmake --build build_artifacts --config RelWithDebInfo > build_artifacts/logs.txt 2>&1 || (
+            echo "Compilation failed. Here are the logs:"
+            type build_artifacts\logs.txt
+            echo "The original compilation commands:"
+            type build_artifacts\compile_commands.json
+            echo:
+            echo "CPU Features:"
+            wmic cpu list /format:list
+            exit 1
+          )
+      - name: Test C++
+        run: .\build_artifacts\stringzilla_test_cpp20.exe
+      - name: Test on Real World Data
+        run: |
+          .\build_artifacts\stringzilla_bench_search.exe ${DATASET_PATH}     # for substring search
+          .\build_artifacts\stringzilla_bench_token.exe ${DATASET_PATH}      # for hashing, equality comparisons, etc.
+          .\build_artifacts\stringzilla_bench_similarity.exe ${DATASET_PATH} # for edit distances and alignment scores
+          .\build_artifacts\stringzilla_bench_sort.exe ${DATASET_PATH}       # for sorting arrays of strings
+          .\build_artifacts\stringzilla_bench_container.exe ${DATASET_PATH}  # for STL containers with string keys
+        env:
+          DATASET_PATH: ./README.md
+        # Don't overload GitHub with our benchmarks.
+        # The results in such an unstable environment will be meaningless anyway.
+        if: 0
+        
+        # Python
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -265,6 +265,7 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@v1
 
       - name: Build C/C++
+        shell: cmd
         run: |
           cmake -GNinja -B build_artifacts ^
             -DCMAKE_BUILD_TYPE=RelWithDebInfo ^

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -42,7 +42,7 @@ jobs:
             -DSTRINGZILLA_BUILD_BENCHMARK=1 \
             -DSTRINGZILLA_BUILD_TEST=1
 
-          cmake --build build_artifacts --config RelWithDebInfo > build_artifacts\logs.txt 2>&1 || {
+          cmake --build build_artifacts --config RelWithDebInfo > build_artifacts/logs.txt 2>&1 || {
             echo "Compilation failed. Here are the logs:"
             cat build_artifacts/logs.txt
             echo "The original compilation commands:"

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 build/
 build_debug/
 build_release/
-build_artifacts/
+build_artifacts*
 
 # Yes, everyone loves keeping this file in the history.
 # But with a very minimalistic binding and just a couple of dependencies 

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 build/
 build_debug/
 build_release/
+build_artifacts/
 
 # Yes, everyone loves keeping this file in the history.
 # But with a very minimalistic binding and just a couple of dependencies 
@@ -27,6 +28,7 @@ CMakeFiles
 *.pyd
 .venv/*
 node_modules/
+.vs/
 
 # Recommended datasets
 leipzig1M.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,9 +239,15 @@ if(${STRINGZILLA_BUILD_TEST})
   # compile multiple backends: disabling all SIMD, enabling only AVX2, only AVX-512, only Arm Neon.
   if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64|amd64")
     # x86 specific backends
-    define_launcher(stringzilla_test_cpp20_x86_serial scripts/test.cpp 20 "ivybridge")
-    define_launcher(stringzilla_test_cpp20_x86_avx2 scripts/test.cpp 20 "haswell")
-    define_launcher(stringzilla_test_cpp20_x86_avx512 scripts/test.cpp 20 "sapphirerapids")
+    if (MSVC)
+      define_launcher(stringzilla_test_cpp20_x86_serial scripts/test.cpp 20 "AVX")
+      define_launcher(stringzilla_test_cpp20_x86_avx2 scripts/test.cpp 20 "AVX2")
+      define_launcher(stringzilla_test_cpp20_x86_avx512 scripts/test.cpp 20 "AVX512")
+    else()
+      define_launcher(stringzilla_test_cpp20_x86_serial scripts/test.cpp 20 "ivybridge")
+      define_launcher(stringzilla_test_cpp20_x86_avx2 scripts/test.cpp 20 "haswell")
+      define_launcher(stringzilla_test_cpp20_x86_avx512 scripts/test.cpp 20 "sapphirerapids")
+    endif()
   elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|AARCH64")
     # ARM specific backends
     define_launcher(stringzilla_test_cpp20_arm_serial scripts/test.cpp 20 "armv8-a")

--- a/include/stringzilla/stringzilla.h
+++ b/include/stringzilla/stringzilla.h
@@ -4507,10 +4507,10 @@ SZ_PUBLIC void sz_hashes_avx512(sz_cptr_t start, sz_size_t length, sz_size_t win
         chars_vec.zmm = _mm512_add_epi8(chars_vec.zmm, shift_vec.zmm);
 
         // ... and prefetch the next four characters into Level 2 or higher.
-        _mm_prefetch(text_fourth + 1, _MM_HINT_T1);
-        _mm_prefetch(text_third + 1, _MM_HINT_T1);
-        _mm_prefetch(text_second + 1, _MM_HINT_T1);
-        _mm_prefetch(text_first + 1, _MM_HINT_T1);
+        _mm_prefetch((sz_cptr_t)text_fourth + 1, _MM_HINT_T1);
+        _mm_prefetch((sz_cptr_t)text_third + 1, _MM_HINT_T1);
+        _mm_prefetch((sz_cptr_t)text_second + 1, _MM_HINT_T1);
+        _mm_prefetch((sz_cptr_t)text_first + 1, _MM_HINT_T1);
 
         // 3. Add the incoming characters.
         hash_vec.zmm = _mm512_add_epi64(hash_vec.zmm, chars_vec.zmm);

--- a/include/stringzilla/stringzilla.hpp
+++ b/include/stringzilla/stringzilla.hpp
@@ -458,10 +458,9 @@ class range_matches {
             return temp;
         }
 
-        bool operator!=(iterator const &other) const noexcept { return !(*this == other); }
-        bool operator==(iterator const &other) const noexcept {
-            return remaining_.size() == other.remaining_.size() && remaining_.data() == other.remaining_.data();
-        }
+        // Assumes both iterators point to the same underlying string
+        bool operator!=(iterator const &other) const noexcept { return remaining_.data() != other.remaining_.data(); }
+        bool operator==(iterator const &other) const noexcept { return remaining_.data() == other.remaining_.data(); }
         bool operator!=(end_sentinel_type) const noexcept { return !remaining_.empty(); }
         bool operator==(end_sentinel_type) const noexcept { return remaining_.empty(); }
     };
@@ -552,10 +551,9 @@ class range_rmatches {
             return temp;
         }
 
-        bool operator!=(iterator const &other) const noexcept { return !(*this == other); }
-        bool operator==(iterator const &other) const noexcept {
-            return remaining_.size() == other.remaining_.size() && remaining_.data() == other.remaining_.data();
-        }
+        // Assumes both iterators point to the same underlying string
+        bool operator!=(iterator const &other) const noexcept { return remaining_.data() + remaining_.size() != other.remaining_.data() + other.remaining_.size(); }
+        bool operator==(iterator const &other) const noexcept { return remaining_.data() + remaining_.size() == other.remaining_.data() + other.remaining_.size(); }
         bool operator!=(end_sentinel_type) const noexcept { return !remaining_.empty(); }
         bool operator==(end_sentinel_type) const noexcept { return remaining_.empty(); }
     };

--- a/include/stringzilla/stringzilla.hpp
+++ b/include/stringzilla/stringzilla.hpp
@@ -459,8 +459,8 @@ class range_matches {
         }
 
         // Assumes both iterators point to the same underlying string
-        bool operator!=(iterator const &other) const noexcept { return remaining_.data() != other.remaining_.data(); }
-        bool operator==(iterator const &other) const noexcept { return remaining_.data() == other.remaining_.data(); }
+        bool operator!=(iterator const &other) const noexcept { return remaining_.begin() != other.remaining_.begin(); }
+        bool operator==(iterator const &other) const noexcept { return remaining_.begin() == other.remaining_.begin(); }
         bool operator!=(end_sentinel_type) const noexcept { return !remaining_.empty(); }
         bool operator==(end_sentinel_type) const noexcept { return remaining_.empty(); }
     };
@@ -552,8 +552,8 @@ class range_rmatches {
         }
 
         // Assumes both iterators point to the same underlying string
-        bool operator!=(iterator const &other) const noexcept { return remaining_.data() + remaining_.size() != other.remaining_.data() + other.remaining_.size(); }
-        bool operator==(iterator const &other) const noexcept { return remaining_.data() + remaining_.size() == other.remaining_.data() + other.remaining_.size(); }
+        bool operator!=(iterator const &other) const noexcept { return remaining_.end() != other.remaining_.end(); }
+        bool operator==(iterator const &other) const noexcept { return remaining_.end() == other.remaining_.end(); }
         bool operator!=(end_sentinel_type) const noexcept { return !remaining_.empty(); }
         bool operator==(end_sentinel_type) const noexcept { return remaining_.empty(); }
     };

--- a/include/stringzilla/stringzilla.hpp
+++ b/include/stringzilla/stringzilla.hpp
@@ -458,8 +458,10 @@ class range_matches {
             return temp;
         }
 
-        bool operator!=(iterator const &other) const noexcept { return remaining_.begin() != other.remaining_.begin(); }
-        bool operator==(iterator const &other) const noexcept { return remaining_.begin() == other.remaining_.begin(); }
+        bool operator!=(iterator const &other) const noexcept { return !(*this == other); }
+        bool operator==(iterator const &other) const noexcept {
+            return remaining_.size() == other.remaining_.size() && remaining_.data() == other.remaining_.data();
+        }
         bool operator!=(end_sentinel_type) const noexcept { return !remaining_.empty(); }
         bool operator==(end_sentinel_type) const noexcept { return remaining_.empty(); }
     };
@@ -550,8 +552,10 @@ class range_rmatches {
             return temp;
         }
 
-        bool operator!=(iterator const &other) const noexcept { return remaining_.end() != other.remaining_.end(); }
-        bool operator==(iterator const &other) const noexcept { return remaining_.end() == other.remaining_.end(); }
+        bool operator!=(iterator const &other) const noexcept { return !(*this == other); }
+        bool operator==(iterator const &other) const noexcept {
+            return remaining_.size() == other.remaining_.size() && remaining_.data() == other.remaining_.data();
+        }
         bool operator!=(end_sentinel_type) const noexcept { return !remaining_.empty(); }
         bool operator==(end_sentinel_type) const noexcept { return remaining_.empty(); }
     };

--- a/scripts/test.cpp
+++ b/scripts/test.cpp
@@ -1,4 +1,10 @@
 #undef NDEBUG      // Enable all assertions
+
+// Enable assertions for iterators
+#if !defined(_ITERATOR_DEBUG_LEVEL) || _ITERATOR_DEBUG_LEVEL == 0
+#define _ITERATOR_DEBUG_LEVEL 1
+#endif
+
 #include <cassert> // assertions
 
 // Overload the following with caution.


### PR DESCRIPTION
Just some fixes for building with MSVC

- Added MSVC C/C++ build to the windows workflow
- Fixed assertion with `range_(r)matches::iterator::operator==` when comparing iterators from different containers in debug mode
- Fixed incorrect `/arch` flags for MSVC when building `stringzilla_test_cpp20_x86_*`