### PR TITLE
Swift tests fixed and added

### DIFF
--- a/swift/Test.swift
+++ b/swift/Test.swift
@@ -44,17 +44,29 @@ class StringZillaTests: XCTestCase {
         XCTAssertEqual(testString[index...], "Hello, world! Welcome to StringZilla. 👋")
     }
 
-    // TODO: This fails!
-    // func testFindLastCharacterNotFromSet() {
-    //     let index = testString.findLast(characterNotFrom: "aeiou")!
-    //     XCTAssertEqual(testString.distance(from: testString.startIndex, to: index), 38)
-    //     XCTAssertEqual(testString[index...], "👋")
-    // }
+     func testFindLastCharacterNotFromSet() {
+        let index = testString.findLast(characterNotFrom: "aeiou")!
+        XCTAssertEqual(testString.distance(from: testString.startIndex, to: index), 38)
+        XCTAssertEqual(testString[index...], "👋")
+    }
     
     func testEditDistance() {
         let otherString = "Hello, world!"
         let distance = try? testString.editDistance(from: otherString) // Using try?
         XCTAssertNotNil(distance)
         XCTAssertEqual(distance, 29)
+    }
+    
+    func testFindLastCharacterNotFromSetWithEmoji() {
+        let index = testString.findLast(characterNotFrom: "aeiou👋")!
+        XCTAssertEqual(testString.distance(from: testString.startIndex, to: index), 37)
+        XCTAssertEqual(testString[index...], " ")
+    }
+    
+    // Additional test: Test finding the last character not from a set when the string only contains characters from the set
+    func testFindLastCharacterNotFromSetNoMatch() {
+        let testString = "aeiou"
+        let index = testString.findLast(characterNotFrom: "aeiou")
+        XCTAssertNil(index)
     }
 }


### PR DESCRIPTION
Hey @ashvardanian do check this PR.....closes issue #77 
In this issue

Two additional test cases have been added:
testFindLastCharacterNotFromSetWithEmoji: This test ensures that the findLast function works correctly when the set of characters includes emojis.
testFindLastCharacterNotFromSetNoMatch: This test verifies the behavior when there is no character that doesn't belong to the provided set.
These tests help ensure that the findLast function works correctly and handles different scenarios effectively.

Thanks