### PR TITLE
Fixed MSVC build & warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ function(set_compiler_flags target cpp_standard target_arch)
   target_compile_options(
     ${target}
     PRIVATE
-    "$<$<CXX_COMPILER_ID:MSVC>:/Bt;/wd4068;/wd4146;/utf-8>" # For MSVC, /WX would have been sufficient
+    "$<$<CXX_COMPILER_ID:MSVC>:/Bt;/wd4068;/wd4146;/utf-8;/WX>"
     "$<$<CXX_COMPILER_ID:GNU>:-Wall;-Wextra;-pedantic;-Werror;-Wfatal-errors;-Wno-unknown-pragmas;-Wno-cast-function-type;-Wno-unused-function>"
     "$<$<CXX_COMPILER_ID:Clang>:-Wall;-Wextra;-pedantic;-Werror;-Wfatal-errors;-Wno-unknown-pragmas>"
     "$<$<CXX_COMPILER_ID:AppleClang>:-Wall;-Wextra;-pedantic;-Werror;-Wfatal-errors;-Wno-unknown-pragmas>"

--- a/c/lib.c
+++ b/c/lib.c
@@ -130,7 +130,11 @@ typedef struct sz_implementations_t {
 
 } sz_implementations_t;
 
+#if defined(_MSC_VER)
+__declspec(align(64)) static sz_implementations_t sz_dispatch_table;
+#else
 __attribute__((aligned(64))) static sz_implementations_t sz_dispatch_table;
+#endif
 
 /**
  *  @brief  Initializes a global static "virtual table" of supported backends

--- a/c/lib.c
+++ b/c/lib.c
@@ -27,12 +27,15 @@
 // If we don't have the LibC, the `malloc` definition in `stringzilla.h` will be illformed.
 #ifdef _MSC_VER
 typedef sz_size_t size_t; // Reuse the type definition we've inferred from `stringzilla.h`
+extern __declspec(dllimport) int rand(void);
+extern __declspec(dllimport) void free(void *start);
+extern __declspec(dllimport) void *malloc(size_t length);
 #else
 typedef __SIZE_TYPE__ size_t; // For GCC/Clang
-#endif
 extern int rand(void);
 extern void free(void *start);
 extern void *malloc(size_t length);
+#endif
 #endif
 
 SZ_DYNAMIC sz_capability_t sz_capabilities(void) {

--- a/include/stringzilla/stringzilla.h
+++ b/include/stringzilla/stringzilla.h
@@ -4990,7 +4990,8 @@ SZ_INTERNAL sz_ssize_t _sz_alignment_score_wagner_fisher_upto17m_avx512( //
                     _mm512_maskz_loadu_epi32((__mmask16)mask, previous_distances + idx_longer + 32);
                 cost_substitution_vec.zmm = _mm512_add_epi32(
                     cost_substitution_vec.zmm, _mm512_cvtepi16_epi32(_mm512_extracti64x4_epi64(current_32_63_vec, 0)));
-                cost_deletion_vec.zmm = _mm512_maskz_loadu_epi32(mask, previous_distances + 1 + idx_longer + 32);
+                cost_deletion_vec.zmm =
+                    _mm512_maskz_loadu_epi32((__mmask16)mask, previous_distances + 1 + idx_longer + 32);
                 cost_deletion_vec.zmm = _mm512_add_epi32(cost_deletion_vec.zmm, gap_vec.zmm);
                 current_vec.zmm = _mm512_max_epi32(cost_substitution_vec.zmm, cost_deletion_vec.zmm);
 

--- a/scripts/bench_sort.cpp
+++ b/scripts/bench_sort.cpp
@@ -203,6 +203,7 @@ int main(int argc, char const **argv) {
             qsort_r(array.order, array.count, sizeof(sz_u64_t), _get_qsort_order, &array);
         });
         expect_sorted(strings, permute_new);
+#elif defined(_MSC_VER)
 #else
         sz_unused(_get_qsort_order);
 #endif


### PR DESCRIPTION
- Fixed unsupported `__attribute__` on MSVC
- Removed all MSVC warnings, so that `/WX` (treat warnings as errors) can now be enabled