### PR TITLE
The wc cli has been fixed up

### DIFF
--- a/cli/wc.py
+++ b/cli/wc.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import sys
+import sys, os
 import argparse
 import stringzilla
 from stringzilla import File, Str
@@ -30,6 +30,13 @@ def parse_arguments():
     parser.add_argument(
         "-w", "--words", action="store_true", help="print the word counts"
     )
+    parser.add_argument(
+        "--files0-from", metavar="filename",
+        help="Read input from the files specified by NUL-terminated names in file F;" 
+                              " If F is - then read names from standard input" 
+    )
+
+    
     parser.add_argument("--version", action="version", version=stringzilla.__version__)
     return parser.parse_args()
 
@@ -45,27 +52,28 @@ def wc(file_path, args):
         except RuntimeError:  # File gives a RuntimeError if the file does not exist
             return f"No such file: {file_path}", False
 
-    line_count = mapped_bytes.count("\n")
-    word_count = mapped_bytes.count(" ") + 1
-    char_count = mapped_bytes.__len__()
-    counts = {
-        "line_count": line_count,
-        "word_count": word_count,
-        "char_count": char_count,
-    }
+    counts = {}    
+    if args.lines:
+        counts["line_count"] = mapped_bytes.count("\n")
+    if args.words:
+        counts["word_count"] = mapped_bytes.count(" ") + 1
+    if args.chars:
+        counts["char_count"] = mapped_bytes.__len__()
 
     if args.max_line_length:
-        max_line_length = max(len(line) for line in str(mapped_bytes).split("\n"))
+        max_line_length = max(len(line) for line in mapped_bytes.split("\n"))
         counts["max_line_length"] = max_line_length
 
-    if args.bytes or args.chars:
-        byte_count = char_count  # assume 1 char = 1 byte
-        counts["byte_count"] = byte_count
+    if args.bytes:
+        if args.chars:
+            counts["byte_count"] = counts["char_count"]
+        else:
+            counts["byte_count"] = mapped_bytes.__len__()
 
     return counts, True
 
 
-def format_output(counts, args):
+def format_output(counts, args, just):
     selected_counts = []
     if args.lines:
         selected_counts.append(counts["line_count"])
@@ -74,19 +82,17 @@ def format_output(counts, args):
     if args.chars:
         selected_counts.append(counts["char_count"])
     if args.bytes:
-        selected_counts.append(counts.get("byte_count", counts["char_count"]))
+        selected_counts.append(counts["byte_count"])
     if args.max_line_length:
         selected_counts.append(counts.get("max_line_length", 0))
 
-    if not any([args.lines, args.words, args.chars, args.bytes, args.max_line_length]):
-        selected_counts = [
-            counts["line_count"],
-            counts["word_count"],
-            counts["char_count"],
-        ]
+    return " ".join(str(count).rjust(just) for count in selected_counts)
 
-    return " ".join(str(count) for count in selected_counts)
-
+def get_files_from(fn):
+    f = open(fn, "r")
+    s = f.read()
+    f.close()
+    return [x for x in s.split("\0") if os.path.isfile(x)]
 
 def main():
     args = parse_arguments()
@@ -97,19 +103,33 @@ def main():
         "max_line_length": 0,
         "byte_count": 0,
     }
+    if not any([args.lines, args.words, args.chars, args.bytes, args.max_line_length]):
+        args.lines = 1
+        args.words = 1
+        args.bytes = 1
+
+    # wc uses the file size to determine column width when printing 
+    if args.files0_from:
+        if args.files[0] == '-':
+            args.files = get_files_from(args.files0_from)
+            if len(args.files) == 0:
+                #print("  No filenames found in ", args.files0_from)
+                exit(0)
+
+    just = max( len(str(os.stat(fn).st_size)) for fn in args.files)
 
     for file_path in args.files:
         counts, success = wc(file_path, args)
         if success:
             for key in total_counts.keys():
                 total_counts[key] += counts.get(key, 0)
-            output = format_output(counts, args) + f" {file_path}"
+            output = format_output(counts, args, just) + f" {file_path}"
             print(output)
         else:
             print(counts)
 
     if len(args.files) > 1:
-        total_output = format_output(total_counts, args) + " total"
+        total_output = format_output(total_counts, args, just) + " total"
         print(total_output)
 
 


### PR DESCRIPTION
In the wc cli I fixed up a couple bugs,  added the files from arg, justified the output to match wc,  and sped up the longest line search. 

ref https://github.com/ashvardanian/StringZilla/issues/97
```
$ time python ../StringZilla/cli/wc.py -L  --files0-from delme
        67 sz.js
     51648 enwik9.txt
        67 sz.js
       102 tst.js
     51884 total

real	0m1.184s
user	0m1.080s
sys	0m0.104s

$ time wc -L --files0-from delme
        67 sz.js
     51648 enwik9.txt
        67 sz.js
       102 tst.js
wc: ''$'\n': No such file or directory
     51648 total

real	0m4.327s
user	0m4.184s
sys	0m0.142s
```