### PR TITLE
fix compilation error on `randomize`

### DIFF
--- a/include/stringzilla/stringzilla.hpp
+++ b/include/stringzilla/stringzilla.hpp
@@ -3766,7 +3766,7 @@ void randomize(basic_string_slice<char_type_> string, generator_type_ &generator
  */
 template <typename char_type_>
 void randomize(basic_string_slice<char_type_> string, string_view alphabet = "abcdefghijklmnopqrstuvwxyz") noexcept {
-    randomize(string, &std::rand, alphabet);
+    randomize(string, std::rand, alphabet);
 }
 
 using sorted_idx_t = sz_sorted_idx_t;


### PR DESCRIPTION
I met compilation error on gcc 14.2.1.

```
  char uuid[36];
  ashvardanian::stringzilla::randomize(ashvardanian::stringzilla::string_span(uuid, 35));
```

The error messages is following:
```

In file included from test07.cpp:15:
include/stringzilla/stringzilla.hpp: In instantiation of ‘void ashvardanian::stringzilla::randomize(basic_string_slice<char_type_>, string_view) [with char_type_ = char; string_view = basic_string_slice<const char>]’:
test07.cpp:39:39:   required from here
   39 |   ashvardanian::stringzilla::randomize(ashvardanian::stringzilla::string_span(uuid, 35));
      |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
include/stringzilla/stringzilla.hpp:3770:14: error: no matching function for call to ‘randomize(ashvardanian::stringzilla::basic_string_slice<char>&, int (*)() noexcept, ashvardanian::stringzilla::string_view&)’
 3770 |     randomize(string, &std::rand, alphabet);
      |     ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
include/stringzilla/stringzilla.hpp:3754:6: note: candidate: ‘void ashvardanian::stringzilla::randomize(basic_string_slice<char_type_>, generator_type_&, string_view) [with char_type_ = char; generator_type_ = int (*)() noexcept; string_view = basic_string_slice<const char>]’ (near match)
 3754 | void randomize(basic_string_slice<char_type_> string, generator_type_ &generator,
      |      ^~~~~~~~~
include/stringzilla/stringzilla.hpp:3754:6: note:   conversion of argument 2 would be ill-formed:
include/stringzilla/stringzilla.hpp:3770:23: error: cannot bind non-const lvalue reference of type ‘int (*&)() noexcept’ to an rvalue of type ‘int (*)() noexcept’
 3770 |     randomize(string, &std::rand, alphabet);
      |                       ^~~~~~~~~~
include/stringzilla/stringzilla.hpp:3769:6: note: candidate: ‘template<class char_type_> void ashvardanian::stringzilla::randomize(basic_string_slice<char_type_>, string_view)’
 3769 | void randomize(basic_string_slice<char_type_> string, string_view alphabet = "abcdefghijklmnopqrstuvwxyz") noexcept {
      |      ^~~~~~~~~
include/stringzilla/stringzilla.hpp:3769:6: note:   candidate expects 2 arguments, 3 provided
```

This PR tries to fix this error.
