### PR TITLE
Try to fix C++ example

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,10 +665,10 @@ sz::string haystack = "some string";
 sz::string_view needle = sz::string_view(haystack).substr(0, 4);
 
 auto substring_position = haystack.find(needle); // Or `rfind`
-auto hash = std::hash<sz::string_view>(haystack); // Compatible with STL's `std::hash`
+auto hash = std::hash<sz::string_view>()(haystack); // Compatible with STL's `std::hash`
 
 haystack.end() - haystack.begin() == haystack.size(); // Or `rbegin`, `rend`
-haystack.find_first_of(" \w\t") == 4; // Or `find_last_of`, `find_first_not_of`, `find_last_not_of`
+haystack.find_first_of(" \v\t") == 4; // Or `find_last_of`, `find_first_not_of`, `find_last_not_of`
 haystack.starts_with(needle) == true; // Or `ends_with`
 haystack.remove_prefix(needle.size()); // Why is this operation in-place?!
 haystack.contains(needle) == true; // STL has this only from C++ 23 onwards


### PR DESCRIPTION
The first example has two issues.

1. There is a compilation error on std::hash due to wrong usage.
2. `\w` is not a valid escape sequence. Does it mean `\v`?

This PR try to fix these.

By the way, there seem to be several other problems with the C++ examples.
Can I submit a PR or issue for these as well? 
Or do you plan to change them drastically in the future?
