### PR TITLE
Checksums in AVX-512, AVX2, NEON

### DIFF
--- a/c/lib.c
+++ b/c/lib.c
@@ -120,6 +120,7 @@ typedef struct sz_implementations_t {
     sz_move_t move;
     sz_fill_t fill;
     sz_look_up_transform_t look_up_transform;
+    sz_checksum_t checksum;
 
     sz_find_byte_t find_byte;
     sz_find_byte_t rfind_byte;
@@ -155,6 +156,7 @@ static void sz_dispatch_table_init(void) {
     impl->move = sz_move_serial;
     impl->fill = sz_fill_serial;
     impl->look_up_transform = sz_look_up_transform_serial;
+    impl->checksum = sz_checksum_serial;
 
     impl->find = sz_find_serial;
     impl->rfind = sz_rfind_serial;
@@ -176,6 +178,7 @@ static void sz_dispatch_table_init(void) {
         impl->move = sz_move_avx2;
         impl->fill = sz_fill_avx2;
         impl->look_up_transform = sz_look_up_transform_avx2;
+        impl->checksum = sz_checksum_avx2;
 
         impl->find_byte = sz_find_byte_avx2;
         impl->rfind_byte = sz_rfind_byte_avx2;
@@ -209,6 +212,7 @@ static void sz_dispatch_table_init(void) {
         impl->rfind_from_set = sz_rfind_charset_avx512;
         impl->alignment_score = sz_alignment_score_avx512;
         impl->look_up_transform = sz_look_up_transform_avx512;
+        impl->checksum = sz_checksum_avx512;
     }
 #endif
 
@@ -220,6 +224,7 @@ static void sz_dispatch_table_init(void) {
         impl->move = sz_move_neon;
         impl->fill = sz_fill_neon;
         impl->look_up_transform = sz_look_up_transform_neon;
+        impl->checksum = sz_checksum_neon;
 
         impl->find = sz_find_neon;
         impl->rfind = sz_rfind_neon;
@@ -250,6 +255,8 @@ BOOL WINAPI DllMain(HINSTANCE hints, DWORD forward_reason, LPVOID lp) {
 #else
 __attribute__((constructor)) static void sz_dispatch_table_init_on_gcc_or_clang(void) { sz_dispatch_table_init(); }
 #endif
+
+SZ_DYNAMIC sz_u64_t sz_checksum(sz_cptr_t text, sz_size_t length) { return sz_dispatch_table.checksum(text, length); }
 
 SZ_DYNAMIC sz_bool_t sz_equal(sz_cptr_t a, sz_cptr_t b, sz_size_t length) {
     return sz_dispatch_table.equal(a, b, length);

--- a/include/stringzilla/stringzilla.h
+++ b/include/stringzilla/stringzilla.h
@@ -4022,7 +4022,7 @@ SZ_PUBLIC sz_u64_t sz_checksum_avx2(sz_cptr_t text, sz_size_t length) {
         __m128i low_xmm = _mm256_castsi256_si128(sums_vec.ymm);
         __m128i high_xmm = _mm256_extracti128_si256(sums_vec.ymm, 1);
         __m128i sums_xmm = _mm_add_epi64(low_xmm, high_xmm);
-        sz_u64_t low = (sz_u64_t)_mm_cvtsi128_si64x(sums_xmm);
+        sz_u64_t low = (sz_u64_t)_mm_cvtsi128_si64(sums_xmm);
         sz_u64_t high = (sz_u64_t)_mm_extract_epi64(sums_xmm, 1);
         sz_u64_t result = low + high;
         if (length) result += sz_checksum_serial(text, length);
@@ -4073,7 +4073,7 @@ SZ_PUBLIC sz_u64_t sz_checksum_avx2(sz_cptr_t text, sz_size_t length) {
         __m128i low_xmm = _mm256_castsi256_si128(sums_vec.ymm);
         __m128i high_xmm = _mm256_extracti128_si256(sums_vec.ymm, 1);
         __m128i sums_xmm = _mm_add_epi64(low_xmm, high_xmm);
-        sz_u64_t low = (sz_u64_t)_mm_cvtsi128_si64x(sums_xmm);
+        sz_u64_t low = (sz_u64_t)_mm_cvtsi128_si64(sums_xmm);
         sz_u64_t high = (sz_u64_t)_mm_extract_epi64(sums_xmm, 1);
         result += low + high;
         return result;
@@ -5306,7 +5306,7 @@ SZ_PUBLIC sz_u64_t sz_checksum_avx512(sz_cptr_t text, sz_size_t length) {
         __mmask16 mask = _sz_u16_mask_until(length);
         text_vec.xmms[0] = _mm_maskz_loadu_epi8(mask, text);
         sums_vec.xmms[0] = _mm_sad_epu8(text_vec.xmms[0], _mm_setzero_si128());
-        sz_u64_t low = (sz_u64_t)_mm_cvtsi128_si64x(sums_vec.xmms[0]);
+        sz_u64_t low = (sz_u64_t)_mm_cvtsi128_si64(sums_vec.xmms[0]);
         sz_u64_t high = (sz_u64_t)_mm_extract_epi64(sums_vec.xmms[0], 1);
         return low + high;
     }
@@ -5318,7 +5318,7 @@ SZ_PUBLIC sz_u64_t sz_checksum_avx512(sz_cptr_t text, sz_size_t length) {
         __m128i low_xmm = _mm256_castsi256_si128(sums_vec.ymms[0]);
         __m128i high_xmm = _mm256_extracti128_si256(sums_vec.ymms[0], 1);
         __m128i sums_xmm = _mm_add_epi64(low_xmm, high_xmm);
-        sz_u64_t low = (sz_u64_t)_mm_cvtsi128_si64x(sums_xmm);
+        sz_u64_t low = (sz_u64_t)_mm_cvtsi128_si64(sums_xmm);
         sz_u64_t high = (sz_u64_t)_mm_extract_epi64(sums_xmm, 1);
         return low + high;
     }
@@ -6092,7 +6092,7 @@ SZ_PUBLIC sz_bool_t sz_equal_neon(sz_cptr_t a, sz_cptr_t b, sz_size_t length) {
     return sz_true_k;
 }
 
-SZ_PUBLIC sz_u64_t sz_checksum_neon(sz_cptr_t const *text, size_t length) {
+SZ_PUBLIC sz_u64_t sz_checksum_neon(sz_cptr_t text, sz_size_t length) {
     uint64x2_t sum_vec = vdupq_n_u64(0);
 
     // Process 16 bytes (128 bits) at a time

--- a/include/stringzilla/stringzilla.h
+++ b/include/stringzilla/stringzilla.h
@@ -414,9 +414,23 @@ typedef union sz_string_t {
 } sz_string_t;
 
 typedef sz_u64_t (*sz_hash_t)(sz_cptr_t, sz_size_t);
+typedef sz_u64_t (*sz_checksum_t)(sz_cptr_t, sz_size_t);
 typedef sz_bool_t (*sz_equal_t)(sz_cptr_t, sz_cptr_t, sz_size_t);
 typedef sz_ordering_t (*sz_order_t)(sz_cptr_t, sz_size_t, sz_cptr_t, sz_size_t);
 typedef void (*sz_to_converter_t)(sz_cptr_t, sz_size_t, sz_ptr_t);
+
+/**
+ *  @brief  Computes the 64-bit check-sum of bytes in a string.
+ *          Similar to `std::ranges::accumulate`.
+ *
+ *  @param text     String to aggregate.
+ *  @param length   Number of bytes in the text.
+ *  @return         64-bit unsigned value.
+ */
+SZ_PUBLIC sz_u64_t sz_checksum(sz_cptr_t text, sz_size_t length);
+
+/** @copydoc sz_checksum */
+SZ_PUBLIC sz_u64_t sz_checksum_serial(sz_cptr_t text, sz_size_t length);
 
 /**
  *  @brief  Computes the 64-bit unsigned hash of a string. Fairly fast for short strings,
@@ -2863,6 +2877,14 @@ SZ_PUBLIC sz_size_t sz_hamming_distance_utf8_serial( //
     return distance;
 }
 
+SZ_PUBLIC sz_u64_t sz_checksum_serial(sz_cptr_t text, sz_size_t length) {
+    sz_u64_t checksum = 0;
+    sz_u8_t const *text_u8 = (sz_u8_t const *)text;
+    sz_u8_t const *text_end = text_u8 + length;
+    for (; text_u8 != text_end; ++text_u8) checksum += *text_u8;
+    return checksum;
+}
+
 /**
  *  @brief  Largest prime number that fits into 31 bits.
  *  @see    https://mersenneforum.org/showthread.php?t=3471
@@ -3978,6 +4000,86 @@ SZ_PUBLIC void sz_move_avx2(sz_ptr_t target, sz_cptr_t source, sz_size_t length)
     }
 }
 
+SZ_PUBLIC sz_u64_t sz_checksum_avx2(sz_cptr_t text, sz_size_t length) {
+    // The naive implementation of this function is very simple.
+    // It assumes the CPU is great at handling unaligned "loads".
+    //
+    // A typical AWS Skylake instance can have 32 KB x 2 blocks of L1 data cache per core,
+    // 1 MB x 2 blocks of L2 cache per core, and one shared L3 cache buffer.
+    // For now, let's avoid the cases beyond the L2 size.
+    int is_huge = length > 1ull * 1024ull * 1024ull;
+
+    // When the buffer is small, there isn't much to innovate.
+    if (length <= 32) { return sz_checksum_serial(text, length); }
+    else if (!is_huge) {
+        sz_u256_vec_t text_vec, sums_vec;
+        sums_vec.ymm = _mm256_setzero_si256();
+        for (; length >= 32; text += 32, length -= 32) {
+            text_vec.ymm = _mm256_lddqu_si256((__m256i const *)text);
+            sums_vec.ymm = _mm256_add_epi64(sums_vec.ymm, _mm256_sad_epu8(text_vec.ymm, _mm256_setzero_si256()));
+        }
+        // Accumulating 256 bits is harders, as we need to extract the 128-bit sums first.
+        __m128i low_xmm = _mm256_castsi256_si128(sums_vec.ymm);
+        __m128i high_xmm = _mm256_extracti128_si256(sums_vec.ymm, 1);
+        __m128i sums_xmm = _mm_add_epi64(low_xmm, high_xmm);
+        sz_u64_t low = (sz_u64_t)_mm_cvtsi128_si64x(sums_xmm);
+        sz_u64_t high = (sz_u64_t)_mm_extract_epi64(sums_xmm, 1);
+        sz_u64_t result = low + high;
+        if (length) result += sz_checksum_serial(text, length);
+        return result;
+    }
+    // For gigantic buffers, exceeding typical L1 cache sizes, there are other tricks we can use.
+    // Most notably, we can avoid populating the cache with the entire buffer, and instead traverse it in 2 directions.
+    else {
+        sz_size_t head_length = (32 - ((sz_size_t)text % 32)) % 32; // 31 or less.
+        sz_size_t tail_length = (sz_size_t)(text + length) % 32;    // 31 or less.
+        sz_size_t body_length = length - head_length - tail_length; // Multiple of 32.
+        sz_u64_t result = 0;
+
+        // Handle the head
+        while (head_length--) result += *text++;
+
+        sz_u256_vec_t text_vec, sums_vec;
+        sums_vec.ymm = _mm256_setzero_si256();
+        // Fill the aligned body of the buffer.
+        if (!is_huge) {
+            for (; body_length >= 32; text += 32, body_length -= 32) {
+                text_vec.ymm = _mm256_stream_load_si256((__m256i const *)text);
+                sums_vec.ymm = _mm256_add_epi64(sums_vec.ymm, _mm256_sad_epu8(text_vec.ymm, _mm256_setzero_si256()));
+            }
+        }
+        // When the biffer is huge, we can traverse it in 2 directions.
+        else {
+            sz_u256_vec_t text_reversed_vec, sums_reversed_vec;
+            sums_reversed_vec.ymm = _mm256_setzero_si256();
+            for (; body_length >= 64; text += 64, body_length -= 64) {
+                text_vec.ymm = _mm256_stream_load_si256((__m256i *)(text));
+                sums_vec.ymm = _mm256_add_epi64(sums_vec.ymm, _mm256_sad_epu8(text_vec.ymm, _mm256_setzero_si256()));
+                text_reversed_vec.ymm = _mm256_stream_load_si256((__m256i *)(text + body_length - 64));
+                sums_reversed_vec.ymm = _mm256_add_epi64(
+                    sums_reversed_vec.ymm, _mm256_sad_epu8(text_reversed_vec.ymm, _mm256_setzero_si256()));
+            }
+            if (body_length >= 32) {
+                text_vec.ymm = _mm256_stream_load_si256((__m256i *)(text));
+                sums_vec.ymm = _mm256_add_epi64(sums_vec.ymm, _mm256_sad_epu8(text_vec.ymm, _mm256_setzero_si256()));
+            }
+            sums_vec.ymm = _mm256_add_epi64(sums_vec.ymm, sums_reversed_vec.ymm);
+        }
+
+        // Handle the tail
+        while (tail_length--) result += *text++;
+
+        // Accumulating 256 bits is harders, as we need to extract the 128-bit sums first.
+        __m128i low_xmm = _mm256_castsi256_si128(sums_vec.ymm);
+        __m128i high_xmm = _mm256_extracti128_si256(sums_vec.ymm, 1);
+        __m128i sums_xmm = _mm_add_epi64(low_xmm, high_xmm);
+        sz_u64_t low = (sz_u64_t)_mm_cvtsi128_si64x(sums_xmm);
+        sz_u64_t high = (sz_u64_t)_mm_extract_epi64(sums_xmm, 1);
+        result += low + high;
+        return result;
+    }
+}
+
 SZ_PUBLIC void sz_look_up_transform_avx2(sz_cptr_t source, sz_size_t length, sz_cptr_t lut, sz_ptr_t target) {
 
     // If the input is tiny (especially smaller than the look-up table itself), we may end up paying
@@ -4500,6 +4602,20 @@ SZ_INTERNAL __mmask16 _sz_u16_clamp_mask_until(sz_size_t n) {
     //      return (1ull << n) - 1;
     // A slightly more complex approach, if we don't know that `n` is under 16:
     return _bzhi_u32(0xFFFFFFFF, n < 16 ? (sz_u32_t)n : 16);
+}
+
+SZ_INTERNAL __mmask16 _sz_u16_mask_until(sz_size_t n) {
+    // The simplest approach to compute this if we know that `n` is blow or equal 16:
+    //      return (1ull << n) - 1;
+    // A slightly more complex approach, if we don't know that `n` is under 16:
+    return (__mmask16)_bzhi_u32(0xFFFFFFFF, (sz_u32_t)n);
+}
+
+SZ_INTERNAL __mmask32 _sz_u32_mask_until(sz_size_t n) {
+    // The simplest approach to compute this if we know that `n` is blow or equal 32:
+    //      return (1ull << n) - 1;
+    // A slightly more complex approach, if we don't know that `n` is under 32:
+    return _bzhi_u32(0xFFFFFFFF, (sz_u32_t)n);
 }
 
 SZ_INTERNAL __mmask64 _sz_u64_mask_until(sz_size_t n) {
@@ -5175,6 +5291,100 @@ SZ_INTERNAL sz_size_t sz_edit_distance_avx512(   //
 #pragma clang attribute push(__attribute__((target("avx,avx512f,avx512vl,avx512bw,avx512dq,bmi,bmi2"))), \
                              apply_to = function)
 
+SZ_PUBLIC sz_u64_t sz_checksum_avx512(sz_cptr_t text, sz_size_t length) {
+    // The naive implementation of this function is very simple.
+    // It assumes the CPU is great at handling unaligned "loads".
+    //
+    // A typical AWS Sapphire Rapids instance can have 48 KB x 2 blocks of L1 data cache per core,
+    // 2 MB x 2 blocks of L2 cache per core, and one shared 60 MB buffer of L3 cache.
+    // With two strings, we may consider the overal workload huge, if each exceeds 1 MB in length.
+    int const is_huge = length >= 1ull * 1024ull * 1024ull;
+    sz_u512_vec_t text_vec, sums_vec;
+
+    // When the buffer is small, there isn't much to innovate.
+    if (length <= 16) {
+        __mmask16 mask = _sz_u16_mask_until(length);
+        text_vec.xmms[0] = _mm_maskz_loadu_epi8(mask, text);
+        sums_vec.xmms[0] = _mm_sad_epu8(text_vec.xmms[0], _mm_setzero_si128());
+        sz_u64_t low = (sz_u64_t)_mm_cvtsi128_si64x(sums_vec.xmms[0]);
+        sz_u64_t high = (sz_u64_t)_mm_extract_epi64(sums_vec.xmms[0], 1);
+        return low + high;
+    }
+    else if (length <= 32) {
+        __mmask32 mask = _sz_u32_mask_until(length);
+        text_vec.ymms[0] = _mm256_maskz_loadu_epi8(mask, text);
+        sums_vec.ymms[0] = _mm256_sad_epu8(text_vec.ymms[0], _mm256_setzero_si256());
+        // Accumulating 256 bits is harders, as we need to extract the 128-bit sums first.
+        __m128i low_xmm = _mm256_castsi256_si128(sums_vec.ymms[0]);
+        __m128i high_xmm = _mm256_extracti128_si256(sums_vec.ymms[0], 1);
+        __m128i sums_xmm = _mm_add_epi64(low_xmm, high_xmm);
+        sz_u64_t low = (sz_u64_t)_mm_cvtsi128_si64x(sums_xmm);
+        sz_u64_t high = (sz_u64_t)_mm_extract_epi64(sums_xmm, 1);
+        return low + high;
+    }
+    else if (length <= 64) {
+        __mmask64 mask = _sz_u64_mask_until(length);
+        text_vec.zmm = _mm512_maskz_loadu_epi8(mask, text);
+        sums_vec.zmm = _mm512_sad_epu8(text_vec.zmm, _mm512_setzero_si512());
+        return _mm512_reduce_add_epi64(sums_vec.zmm);
+    }
+    else if (!is_huge) {
+        sz_size_t head_length = (64 - ((sz_size_t)text % 64)) % 64; // 63 or less.
+        sz_size_t tail_length = (sz_size_t)(text + length) % 64;    // 63 or less.
+        sz_size_t body_length = length - head_length - tail_length; // Multiple of 64.
+        __mmask64 head_mask = _sz_u64_mask_until(head_length);
+        __mmask64 tail_mask = _sz_u64_mask_until(tail_length);
+        text_vec.zmm = _mm512_maskz_loadu_epi8(head_mask, text);
+        sums_vec.zmm = _mm512_sad_epu8(text_vec.zmm, _mm512_setzero_si512());
+        for (text += head_length; body_length >= 64; text += 64, body_length -= 64) {
+            text_vec.zmm = _mm512_load_si512((__m512i const *)text);
+            sums_vec.zmm = _mm512_add_epi64(sums_vec.zmm, _mm512_sad_epu8(text_vec.zmm, _mm512_setzero_si512()));
+        }
+        text_vec.zmm = _mm512_maskz_loadu_epi8(tail_mask, text);
+        sums_vec.zmm = _mm512_add_epi64(sums_vec.zmm, _mm512_sad_epu8(text_vec.zmm, _mm512_setzero_si512()));
+        return _mm512_reduce_add_epi64(sums_vec.zmm);
+    }
+    // For gigantic buffers, exceeding typical L1 cache sizes, there are other tricks we can use.
+    //
+    //      1. Moving in both directions to maximize the throughput, when fetching from multiple
+    //         memory pages. Also helps with cache set-associativity issues, as we won't always
+    //         be fetching the same entries in the lookup table.
+    //      2. Using non-temporal stores to avoid polluting the cache.
+    //      3. Prefetching the next cache line, to avoid stalling the CPU. This generally useless
+    //         for predictable patterns, so disregard this advice.
+    //
+    // Bidirectional traversal generally adds about 10% to such algorithms.
+    else {
+        sz_u512_vec_t text_reversed_vec, sums_reversed_vec;
+        sz_size_t head_length = (64 - ((sz_size_t)text % 64)) % 64;
+        sz_size_t tail_length = (sz_size_t)(text + length) % 64;
+        sz_size_t body_length = length - head_length - tail_length;
+        __mmask64 head_mask = _sz_u64_mask_until(head_length);
+        __mmask64 tail_mask = _sz_u64_mask_until(tail_length);
+
+        text_vec.zmm = _mm512_maskz_loadu_epi8(head_mask, text);
+        sums_vec.zmm = _mm512_sad_epu8(text_vec.zmm, _mm512_setzero_si512());
+        text_reversed_vec.zmm = _mm512_maskz_loadu_epi8(tail_mask, text + head_length + body_length);
+        sums_reversed_vec.zmm = _mm512_sad_epu8(text_reversed_vec.zmm, _mm512_setzero_si512());
+
+        // Now in the main loop, we can use non-temporal loads and stores,
+        // performing the operation in both directions.
+        for (text += head_length; body_length >= 128; text += 64, text += 64, body_length -= 128) {
+            text_vec.zmm = _mm512_stream_load_si512((__m512i *)(text));
+            sums_vec.zmm = _mm512_add_epi64(sums_vec.zmm, _mm512_sad_epu8(text_vec.zmm, _mm512_setzero_si512()));
+            text_reversed_vec.zmm = _mm512_stream_load_si512((__m512i *)(text + body_length - 64));
+            sums_reversed_vec.zmm =
+                _mm512_add_epi64(sums_reversed_vec.zmm, _mm512_sad_epu8(text_reversed_vec.zmm, _mm512_setzero_si512()));
+        }
+        if (body_length >= 64) {
+            text_vec.zmm = _mm512_stream_load_si512((__m512i *)(text));
+            sums_vec.zmm = _mm512_add_epi64(sums_vec.zmm, _mm512_sad_epu8(text_vec.zmm, _mm512_setzero_si512()));
+        }
+
+        return _mm512_reduce_add_epi64(_mm512_add_epi64(sums_vec.zmm, sums_reversed_vec.zmm));
+    }
+}
+
 SZ_PUBLIC void sz_hashes_avx512(sz_cptr_t start, sz_size_t length, sz_size_t window_length, sz_size_t step, //
                                 sz_hash_callback_t callback, void *callback_handle) {
 
@@ -5770,6 +5980,62 @@ SZ_INTERNAL sz_ssize_t sz_alignment_score_avx512( //
         return sz_alignment_score_serial(shorter, shorter_length, longer, longer_length, subs, gap, alloc);
 }
 
+enum sz_encoding_t {
+    sz_encoding_unknown_k = 0,
+    sz_encoding_ascii_k = 1,
+    sz_encoding_utf8_k = 2,
+    sz_encoding_utf16_k = 3,
+    sz_encoding_utf32_k = 4,
+    sz_jwt_k,
+    sz_base64_k,
+    // Low priority encodings:
+    sz_encoding_utf8bom_k = 5,
+    sz_encoding_utf16le_k = 6,
+    sz_encoding_utf16be_k = 7,
+    sz_encoding_utf32le_k = 8,
+    sz_encoding_utf32be_k = 9,
+};
+
+// Character Set Detection is one of the most commonly performed operations in data processing with
+// [Chardet](https://github.com/chardet/chardet), [Charset Normalizer](https://github.com/jawah/charset_normalizer),
+// [cChardet](https://github.com/PyYoshi/cChardet) being the most commonly used options in the Python ecosystem.
+// All of them are notoriously slow.
+//
+// Moreover, as of October 2024, UTF-8 is the dominant character encoding on the web, used by 98.4% of websites.
+// Other have minimal usage, according to [W3Techs](https://w3techs.com/technologies/overview/character_encoding):
+// - ISO-8859-1: 1.2%
+// - Windows-1252: 0.3%
+// - Windows-1251: 0.2%
+// - EUC-JP: 0.1%
+// - Shift JIS: 0.1%
+// - EUC-KR: 0.1%
+// - GB2312: 0.1%
+// - Windows-1250: 0.1%
+// Within programming language implementations and database management systems, 16-bit and 32-bit fixed-width encodings
+// are also very popular and we need a way to efficienly differentiate between the most common UTF flavors, ASCII, and
+// the rest.
+//
+// One good solution is the [simdutf](https://github.com/simdutf/simdutf) library, but it depends on the C++ runtime
+// and focuses more on incremental validation & transcoding, rather than detection.
+//
+// So we need a very fast and efficient way of determining
+SZ_PUBLIC sz_bool_t sz_detect_encoding(sz_cptr_t text, sz_size_t length) {
+    // https://github.com/simdutf/simdutf/blob/master/src/icelake/icelake_utf8_validation.inl.cpp
+    // https://github.com/simdutf/simdutf/blob/603070affe68101e9e08ea2de19ea5f3f154cf5d/src/icelake/icelake_from_utf8.inl.cpp#L81
+    // https://github.com/simdutf/simdutf/blob/603070affe68101e9e08ea2de19ea5f3f154cf5d/src/icelake/icelake_utf8_common.inl.cpp#L661
+    // https://github.com/simdutf/simdutf/blob/603070affe68101e9e08ea2de19ea5f3f154cf5d/src/icelake/icelake_utf8_common.inl.cpp#L788
+
+    // We can implement this operation simpler & differently, assuming most of the time continuous chunks of memory
+    // have identical encoding. With Russian and many European languages, we generally deal with 2-byte codepoints
+    // with occasional 1-byte punctuation marks. In the case of Chinese, Japanese, and Korean, we deal with 3-byte
+    // codepoints. In the case of emojis, we deal with 4-byte codepoints.
+    // We can also use the idea, that misaligned reads are quite cheap on modern CPUs.
+    int can_be_ascii = 1, can_be_utf8 = 1, can_be_utf16 = 1, can_be_utf32 = 1;
+    sz_unused(can_be_ascii + can_be_utf8 + can_be_utf16 + can_be_utf32);
+    sz_unused(text && length);
+    return sz_false_k;
+}
+
 #pragma clang attribute pop
 #pragma GCC pop_options
 #endif
@@ -5824,6 +6090,24 @@ SZ_PUBLIC sz_bool_t sz_equal_neon(sz_cptr_t a, sz_cptr_t b, sz_size_t length) {
     // Handle remaining bytes
     if (length) return sz_equal_serial(a, b, length);
     return sz_true_k;
+}
+
+SZ_PUBLIC sz_u64_t sz_checksum_neon(sz_cptr_t const *text, size_t length) {
+    uint64x2_t sum_vec = vdupq_n_u64(0);
+
+    // Process 16 bytes (128 bits) at a time
+    for (; length >= 16; text += 16, length -= 16) {
+        uint8x16_t vec = vld1q_u8((sz_u8_t const *)text);      // Load 16 bytes
+        uint16x8_t pairwise_sum1 = vpaddlq_u8(vec);            // Pairwise add lower and upper 8 bits
+        uint32x4_t pairwise_sum2 = vpaddlq_u16(pairwise_sum1); // Pairwise add 16-bit results
+        uint64x2_t pairwise_sum3 = vpaddlq_u32(pairwise_sum2); // Pairwise add 32-bit results
+        sum_vec = vaddq_u64(sum_vec, pairwise_sum3);           // Accumulate the sum
+    }
+
+    // Final reduction of `sum_vec` to a single scalar
+    sz_u64_t sum = vgetq_lane_u64(sum_vec, 0) + vgetq_lane_u64(sum_vec, 1);
+    if (length) sum += sz_checksum_serial(text, length);
+    return sum;
 }
 
 SZ_PUBLIC void sz_copy_neon(sz_ptr_t target, sz_cptr_t source, sz_size_t length) {
@@ -6300,6 +6584,18 @@ SZ_PUBLIC void sz_hashes_fingerprint(sz_cptr_t start, sz_size_t length, sz_size_
 }
 
 #if !SZ_DYNAMIC_DISPATCH
+
+SZ_DYNAMIC sz_u64_t sz_checksum(sz_cptr_t text, sz_size_t length) {
+#if SZ_USE_X86_AVX512
+    return sz_checksum_avx512(text, length);
+#elif SZ_USE_X86_AVX2
+    return sz_checksum_avx2(text, length);
+#elif SZ_USE_ARM_NEON
+    return sz_checksum_neon(text, length);
+#else
+    return sz_checksum_serial(text, length);
+#endif
+}
 
 SZ_DYNAMIC sz_bool_t sz_equal(sz_cptr_t a, sz_cptr_t b, sz_size_t length) {
 #if SZ_USE_X86_AVX512

--- a/include/stringzilla/stringzilla.h
+++ b/include/stringzilla/stringzilla.h
@@ -427,7 +427,7 @@ typedef void (*sz_to_converter_t)(sz_cptr_t, sz_size_t, sz_ptr_t);
  *  @param length   Number of bytes in the text.
  *  @return         64-bit unsigned value.
  */
-SZ_PUBLIC sz_u64_t sz_checksum(sz_cptr_t text, sz_size_t length);
+SZ_DYNAMIC sz_u64_t sz_checksum(sz_cptr_t text, sz_size_t length);
 
 /** @copydoc sz_checksum */
 SZ_PUBLIC sz_u64_t sz_checksum_serial(sz_cptr_t text, sz_size_t length);

--- a/include/stringzilla/stringzilla.hpp
+++ b/include/stringzilla/stringzilla.hpp
@@ -1909,6 +1909,9 @@ class basic_string_slice {
     /**  @brief  Hashes the string, equivalent to `std::hash<string_view>{}(str)`. */
     size_type hash() const noexcept { return static_cast<size_type>(sz_hash(start_, length_)); }
 
+    /**  @brief  Aggregates the values of individual bytes of a string. */
+    size_type checksum() const noexcept { return static_cast<size_type>(sz_checksum(start_, length_)); }
+
     /**  @brief  Populate a character set with characters present in this string. */
     char_set as_set() const noexcept {
         char_set set;
@@ -3302,6 +3305,9 @@ class basic_string {
 
     /**  @brief  Hashes the string, equivalent to `std::hash<string_view>{}(str)`. */
     size_type hash() const noexcept { return view().hash(); }
+
+    /**  @brief  Aggregates the values of individual bytes of a string. */
+    size_type checksum() const noexcept { return view().checksum(); }
 
     /**
      *  @brief  Overwrites the string with random characters from the given alphabet using the random generator.

--- a/python/lib.c
+++ b/python/lib.c
@@ -685,13 +685,13 @@ static PyObject *Str_repr(Str *self) {
 static Py_hash_t Str_hash(Str *self) { return (Py_hash_t)sz_hash(self->memory.start, self->memory.length); }
 
 static char const doc_like_hash[] = //
-    "Compute the hash value of the string.\n\n"
-    "This function can be called as a method on a Str object or as a standalone function.\n\n"
+    "Compute the hash value of the string.\n"
+    "\n"
+    "This function can be called as a method on a Str object or as a standalone function.\n"
     "Args:\n"
-    "  self (Str or str or bytes): The string object (if called as a method).\n"
-    "  text (str): The string to hash (if called as a function).\n\n"
+    "  text (Str or str or bytes): The string to hash.\n"
     "Returns:\n"
-    "  int: The hash value of the string.\n\n"
+    "  int: The hash value of the string.\n"
     "Raises:\n"
     "  TypeError: If the argument is not string-like or incorrect number of arguments is provided.";
 
@@ -751,13 +751,14 @@ static PyObject *Str_like_checksum(PyObject *self, PyObject *args, PyObject *kwa
 }
 
 static char const doc_like_equal[] = //
-    "Compute the equals value of the string.\n\n"
-    "This function can be called as a method on a Str object or as a standalone function.\n\n"
+    "Check if two strings are equal.\n"
+    "\n"
+    "This function can be called as a method on a Str object or as a standalone function.\n"
     "Args:\n"
-    "  self (Str or str or bytes): The string object (if called as a method).\n"
-    "  text (str): The string to equals (if called as a function).\n\n"
+    "  first (Str or str or bytes): The first string object.\n"
+    "  second (Str or str or bytes): The second string object.\n"
     "Returns:\n"
-    "  int: The equals value of the string.\n\n"
+    "  bool: True if the strings are equal, False otherwise.\n"
     "Raises:\n"
     "  TypeError: If the argument is not string-like or incorrect number of arguments is provided.";
 
@@ -1297,13 +1298,14 @@ static PyObject *Strs_richcompare(PyObject *self, PyObject *other, int op) {
 }
 
 static char const doc_decode[] = //
-    "Decode the bytes into a Unicode string with a given encoding.\n\n"
+    "Decode the bytes into a Unicode string with a given encoding.\n"
+    "\n"
     "Args:\n"
-    "  self (Str or str or bytes): The string object.\n"
+    "  text (Str or str or bytes): The string object.\n"
     "  encoding (str, optional): The encoding to use (default is 'utf-8').\n"
-    "  errors (str, optional): Error handling scheme (default is 'strict').\n\n"
+    "  errors (str, optional): Error handling scheme (default is 'strict').\n"
     "Returns:\n"
-    "  str: The decoded Unicode string.\n\n"
+    "  str: The decoded Unicode string.\n"
     "Raises:\n"
     "  UnicodeDecodeError: If decoding fails.";
 
@@ -1350,10 +1352,11 @@ static PyObject *Str_decode(PyObject *self, PyObject *args, PyObject *kwargs) {
 }
 
 static char const doc_write_to[] = //
-    "Write the string to a file.\n\n"
+    "Write the string to a file.\n"
+    "\n"
     "Args:\n"
-    "  self (Str or str or bytes): The string object.\n"
-    "  filename (str): The file path to write to.\n\n"
+    "  text (Str or str or bytes): The string object.\n"
+    "  filename (str): The file path to write to.\n"
     "Returns:\n"
     "  None.";
 
@@ -1428,10 +1431,11 @@ static PyObject *Str_write_to(PyObject *self, PyObject *args, PyObject *kwargs) 
 }
 
 static char const doc_offset_within[] = //
-    "Return the raw byte offset of this StringZilla string within a larger StringZilla string.\n\n"
+    "Return the raw byte offset of this StringZilla string within a larger StringZilla string.\n"
+    "\n"
     "Args:\n"
-    "  self (Str or str or bytes): The substring.\n"
-    "  larger (Str): The larger string to search within.\n\n"
+    "  text (Str or str or bytes): The substring.\n"
+    "  larger (Str): The larger string to search within.\n"
     "Returns:\n"
     "  int: The byte offset where 'self' is found within 'larger', or -1 if not found.";
 
@@ -1558,12 +1562,13 @@ static int _Str_find_implementation_( //
 }
 
 static char const doc_contains[] = //
-    "Check if a string contains a substring.\n\n"
+    "Check if a string contains a substring.\n"
+    "\n"
     "Args:\n"
-    "  self (Str or str or bytes): The string object.\n"
+    "  text (Str or str or bytes): The string object.\n"
     "  substring (str): The substring to search for.\n"
     "  start (int, optional): The starting index (default is 0).\n"
-    "  end (int, optional): The ending index (default is the string length).\n\n"
+    "  end (int, optional): The ending index (default is the string length).\n"
     "Returns:\n"
     "  bool: True if the substring is found, False otherwise.";
 
@@ -1578,12 +1583,13 @@ static PyObject *Str_contains(PyObject *self, PyObject *args, PyObject *kwargs) 
 }
 
 static char const doc_find[] = //
-    "Find the first occurrence of a substring.\n\n"
+    "Find the first occurrence of a substring.\n"
+    "\n"
     "Args:\n"
-    "  self (Str or str or bytes): The string object.\n"
+    "  text (Str or str or bytes): The string object.\n"
     "  substring (str): The substring to find.\n"
     "  start (int, optional): The starting index (default is 0).\n"
-    "  end (int, optional): The ending index (default is the string length).\n\n"
+    "  end (int, optional): The ending index (default is the string length).\n"
     "Returns:\n"
     "  int: The index of the first occurrence, or -1 if not found.";
 
@@ -1597,14 +1603,15 @@ static PyObject *Str_find(PyObject *self, PyObject *args, PyObject *kwargs) {
 }
 
 static char const doc_index[] = //
-    "Find the first occurrence of a substring or raise an error if not found.\n\n"
+    "Find the first occurrence of a substring or raise an error if not found.\n"
+    "\n"
     "Args:\n"
-    "  self (Str or str or bytes): The string object.\n"
+    "  text (Str or str or bytes): The string object.\n"
     "  substring (str): The substring to find.\n"
     "  start (int, optional): The starting index (default is 0).\n"
-    "  end (int, optional): The ending index (default is the string length).\n\n"
+    "  end (int, optional): The ending index (default is the string length).\n"
     "Returns:\n"
-    "  int: The index of the first occurrence.\n\n"
+    "  int: The index of the first occurrence.\n"
     "Raises:\n"
     "  ValueError: If the substring is not found.";
 
@@ -1622,12 +1629,13 @@ static PyObject *Str_index(PyObject *self, PyObject *args, PyObject *kwargs) {
 }
 
 static char const doc_rfind[] = //
-    "Find the last occurrence of a substring.\n\n"
+    "Find the last occurrence of a substring.\n"
+    "\n"
     "Args:\n"
-    "  self (Str or str or bytes): The string object.\n"
+    "  text (Str or str or bytes): The string object.\n"
     "  substring (str): The substring to find.\n"
     "  start (int, optional): The starting index (default is 0).\n"
-    "  end (int, optional): The ending index (default is the string length).\n\n"
+    "  end (int, optional): The ending index (default is the string length).\n"
     "Returns:\n"
     "  int: The index of the last occurrence, or -1 if not found.";
 
@@ -1641,14 +1649,15 @@ static PyObject *Str_rfind(PyObject *self, PyObject *args, PyObject *kwargs) {
 }
 
 static char const doc_rindex[] = //
-    "Find the last occurrence of a substring or raise an error if not found.\n\n"
+    "Find the last occurrence of a substring or raise an error if not found.\n"
+    "\n"
     "Args:\n"
-    "  self (Str or str or bytes): The string object.\n"
+    "  text (Str or str or bytes): The string object.\n"
     "  substring (str): The substring to find.\n"
     "  start (int, optional): The starting index (default is 0).\n"
-    "  end (int, optional): The ending index (default is the string length).\n\n"
+    "  end (int, optional): The ending index (default is the string length).\n"
     "Returns:\n"
-    "  int: The index of the last occurrence.\n\n"
+    "  int: The index of the last occurrence.\n"
     "Raises:\n"
     "  ValueError: If the substring is not found.";
 
@@ -1721,10 +1730,11 @@ static PyObject *_Str_partition_implementation(PyObject *self, PyObject *args, P
 }
 
 static char const doc_partition[] = //
-    "Split the string into a 3-tuple around the first occurrence of a separator.\n\n"
+    "Split the string into a 3-tuple around the first occurrence of a separator.\n"
+    "\n"
     "Args:\n"
-    "  self (Str or str or bytes): The string object.\n"
-    "  separator (str): The separator to partition by.\n\n"
+    "  text (Str or str or bytes): The string object.\n"
+    "  separator (str): The separator to partition by.\n"
     "Returns:\n"
     "  tuple: A 3-tuple (head, separator, tail). If the separator is not found, returns (self, '', '').";
 
@@ -1733,10 +1743,11 @@ static PyObject *Str_partition(PyObject *self, PyObject *args, PyObject *kwargs)
 }
 
 static char const doc_rpartition[] = //
-    "Split the string into a 3-tuple around the last occurrence of a separator.\n\n"
+    "Split the string into a 3-tuple around the last occurrence of a separator.\n"
+    "\n"
     "Args:\n"
-    "  self (Str or str or bytes): The string object.\n"
-    "  separator (str): The separator to partition by.\n\n"
+    "  text (Str or str or bytes): The string object.\n"
+    "  separator (str): The separator to partition by.\n"
     "Returns:\n"
     "  tuple: A 3-tuple (head, separator, tail). If the separator is not found, returns ('', '', self).";
 
@@ -1745,13 +1756,14 @@ static PyObject *Str_rpartition(PyObject *self, PyObject *args, PyObject *kwargs
 }
 
 static char const doc_count[] = //
-    "Count the occurrences of a substring.\n\n"
+    "Count the occurrences of a substring.\n"
+    "\n"
     "Args:\n"
-    "  self (Str or str or bytes): The string object.\n"
+    "  text (Str or str or bytes): The string object.\n"
     "  substring (str): The substring to count.\n"
     "  start (int, optional): The starting index (default is 0).\n"
     "  end (int, optional): The ending index (default is the string length).\n"
-    "  allowoverlap (bool, optional): Count overlapping occurrences (default is False).\n\n"
+    "  allowoverlap (bool, optional): Count overlapping occurrences (default is False).\n"
     "Returns:\n"
     "  int: The number of occurrences of the substring.";
 
@@ -1878,11 +1890,12 @@ static PyObject *_Str_edit_distance(PyObject *self, PyObject *args, PyObject *kw
 }
 
 static char const doc_edit_distance[] = //
-    "Compute the Levenshtein edit distance between two strings.\n\n"
+    "Compute the Levenshtein edit distance between two strings.\n"
+    "\n"
     "Args:\n"
-    "  self (Str or str or bytes): The first string.\n"
+    "  text (Str or str or bytes): The first string.\n"
     "  other (str): The second string to compare.\n"
-    "  bound (int, optional): Optional maximum distance to compute (default is no bound).\n\n"
+    "  bound (int, optional): Optional maximum distance to compute (default is no bound).\n"
     "Returns:\n"
     "  int: The edit distance (number of insertions, deletions, substitutions).";
 
@@ -1891,11 +1904,12 @@ static PyObject *Str_edit_distance(PyObject *self, PyObject *args, PyObject *kwa
 }
 
 static char const doc_edit_distance_unicode[] = //
-    "Compute the Levenshtein edit distance between two Unicode strings.\n\n"
+    "Compute the Levenshtein edit distance between two Unicode strings.\n"
+    "\n"
     "Args:\n"
-    "  self (Str or str or bytes): The first string.\n"
+    "  text (Str or str or bytes): The first string.\n"
     "  other (str): The second string to compare.\n"
-    "  bound (int, optional): Optional maximum distance to compute (default is no bound).\n\n"
+    "  bound (int, optional): Optional maximum distance to compute (default is no bound).\n"
     "Returns:\n"
     "  int: The edit distance in Unicode characters.";
 
@@ -1950,11 +1964,12 @@ static PyObject *_Str_hamming_distance(PyObject *self, PyObject *args, PyObject 
 }
 
 static char const doc_hamming_distance[] = //
-    "Compute the Hamming distance between two strings.\n\n"
+    "Compute the Hamming distance between two strings.\n"
+    "\n"
     "Args:\n"
-    "  self (Str or str or bytes): The first string.\n"
+    "  text (Str or str or bytes): The first string.\n"
     "  other (str): The second string to compare.\n"
-    "  bound (int, optional): Optional maximum distance to compute (default is no bound).\n\n"
+    "  bound (int, optional): Optional maximum distance to compute (default is no bound).\n"
     "Returns:\n"
     "  int: The Hamming distance, including differing bytes and length difference.";
 
@@ -1963,11 +1978,12 @@ static PyObject *Str_hamming_distance(PyObject *self, PyObject *args, PyObject *
 }
 
 static char const doc_hamming_distance_unicode[] = //
-    "Compute the Hamming distance between two Unicode strings.\n\n"
+    "Compute the Hamming distance between two Unicode strings.\n"
+    "\n"
     "Args:\n"
-    "  self (Str or str or bytes): The first string.\n"
+    "  text (Str or str or bytes): The first string.\n"
     "  other (str): The second string to compare.\n"
-    "  bound (int, optional): Optional maximum distance to compute (default is no bound).\n\n"
+    "  bound (int, optional): Optional maximum distance to compute (default is no bound).\n"
     "Returns:\n"
     "  int: The Hamming distance, including differing Unicode characters and length difference.";
 
@@ -1976,13 +1992,14 @@ static PyObject *Str_hamming_distance_unicode(PyObject *self, PyObject *args, Py
 }
 
 static char const doc_alignment_score[] = //
-    "Compute the Needleman-Wunsch alignment score between two strings.\n\n"
+    "Compute the Needleman-Wunsch alignment score between two strings.\n"
+    "\n"
     "Args:\n"
-    "  self (Str or str or bytes): The first string.\n"
+    "  text (Str or str or bytes): The first string.\n"
     "  other (str): The second string to align.\n"
     "  substitution_matrix (numpy.ndarray): A 256x256 substitution cost matrix.\n"
     "  gap_score (int): The score for introducing a gap.\n"
-    "  bound (int, optional): Optional maximum score to compute (default is no bound).\n\n"
+    "  bound (int, optional): Optional maximum score to compute (default is no bound).\n"
     "Returns:\n"
     "  int: The alignment score.";
 
@@ -2074,12 +2091,13 @@ static PyObject *Str_alignment_score(PyObject *self, PyObject *args, PyObject *k
 }
 
 static char const doc_startswith[] = //
-    "Check if a string starts with a given prefix.\n\n"
+    "Check if a string starts with a given prefix.\n"
+    "\n"
     "Args:\n"
-    "  self (Str or str or bytes): The string object.\n"
+    "  text (Str or str or bytes): The string object.\n"
     "  prefix (str): The prefix to check.\n"
     "  start (int, optional): The starting index (default is 0).\n"
-    "  end (int, optional): The ending index (default is the string length).\n\n"
+    "  end (int, optional): The ending index (default is the string length).\n"
     "Returns:\n"
     "  bool: True if the string starts with the prefix, False otherwise.";
 
@@ -2127,12 +2145,13 @@ static PyObject *Str_startswith(PyObject *self, PyObject *args, PyObject *kwargs
 }
 
 static char const doc_endswith[] = //
-    "Check if a string ends with a given suffix.\n\n"
+    "Check if a string ends with a given suffix.\n"
+    "\n"
     "Args:\n"
-    "  self (Str or str or bytes): The string object.\n"
+    "  text (Str or str or bytes): The string object.\n"
     "  suffix (str): The suffix to check.\n"
     "  start (int, optional): The starting index (default is 0).\n"
-    "  end (int, optional): The ending index (default is the string length).\n\n"
+    "  end (int, optional): The ending index (default is the string length).\n"
     "Returns:\n"
     "  bool: True if the string ends with the suffix, False otherwise.";
 
@@ -2180,15 +2199,17 @@ static PyObject *Str_endswith(PyObject *self, PyObject *args, PyObject *kwargs) 
 }
 
 static char const doc_translate[] = //
-    "Perform transformation of a string using a look-up table.\n\n"
+    "Perform transformation of a string using a look-up table.\n"
+    "\n"
     "Args:\n"
-    "  self (Str or str or bytes): The string object.\n"
+    "  text (Str or str or bytes): The string object.\n"
     "  table (str or dict): A 256-character string or a dictionary mapping bytes to bytes.\n"
-    "  inplace (bool, optional): If True, the string is modified in place (default is False).\n\n"
+    "  inplace (bool, optional): If True, the string is modified in place (default is False).\n"
+    "\n"
     "  start (int, optional): The starting index for translation (default is 0).\n"
-    "  end (int, optional): The ending index for translation (default is the string length).\n\n"
+    "  end (int, optional): The ending index for translation (default is the string length).\n"
     "Returns:\n"
-    "  Union[None, str, bytes]: If inplace is False, a new string is returned, otherwise None.\n\n"
+    "  Union[None, str, bytes]: If inplace is False, a new string is returned, otherwise None.\n"
     "Raises:\n"
     "  ValueError: If the table is not 256 bytes long.\n"
     "  TypeError: If the table is not a string or dictionary.";
@@ -2320,12 +2341,13 @@ static PyObject *Str_translate(PyObject *self, PyObject *args, PyObject *kwargs)
 }
 
 static char const doc_find_first_of[] = //
-    "Find the index of the first occurrence of any character from another string.\n\n"
+    "Find the index of the first occurrence of any character from another string.\n"
+    "\n"
     "Args:\n"
-    "  self (Str or str or bytes): The string object.\n"
+    "  text (Str or str or bytes): The string object.\n"
     "  chars (str): A string containing characters to search for.\n"
     "  start (int, optional): Starting index (default is 0).\n"
-    "  end (int, optional): Ending index (default is the string length).\n\n"
+    "  end (int, optional): Ending index (default is the string length).\n"
     "Returns:\n"
     "  int: Index of the first matching character, or -1 if none found.";
 
@@ -2340,12 +2362,13 @@ static PyObject *Str_find_first_of(PyObject *self, PyObject *args, PyObject *kwa
 }
 
 static char const doc_find_first_not_of[] = //
-    "Find the index of the first character not in another string.\n\n"
+    "Find the index of the first character not in another string.\n"
+    "\n"
     "Args:\n"
-    "  self (Str or str or bytes): The string object.\n"
+    "  text (Str or str or bytes): The string object.\n"
     "  chars (str): A string containing characters to exclude.\n"
     "  start (int, optional): Starting index (default is 0).\n"
-    "  end (int, optional): Ending index (default is the string length).\n\n"
+    "  end (int, optional): Ending index (default is the string length).\n"
     "Returns:\n"
     "  int: Index of the first non-matching character, or -1 if all match.";
 
@@ -2360,12 +2383,13 @@ static PyObject *Str_find_first_not_of(PyObject *self, PyObject *args, PyObject 
 }
 
 static char const doc_find_last_of[] = //
-    "Find the index of the last occurrence of any character from another string.\n\n"
+    "Find the index of the last occurrence of any character from another string.\n"
+    "\n"
     "Args:\n"
-    "  self (Str or str or bytes): The string object.\n"
+    "  text (Str or str or bytes): The string object.\n"
     "  chars (str): A string containing characters to search for.\n"
     "  start (int, optional): Starting index (default is 0).\n"
-    "  end (int, optional): Ending index (default is the string length).\n\n"
+    "  end (int, optional): Ending index (default is the string length).\n"
     "Returns:\n"
     "  int: Index of the last matching character, or -1 if none found.";
 
@@ -2380,12 +2404,13 @@ static PyObject *Str_find_last_of(PyObject *self, PyObject *args, PyObject *kwar
 }
 
 static char const doc_find_last_not_of[] = //
-    "Find the index of the last character not in another string.\n\n"
+    "Find the index of the last character not in another string.\n"
+    "\n"
     "Args:\n"
-    "  self (Str or str or bytes): The string object.\n"
+    "  text (Str or str or bytes): The string object.\n"
     "  chars (str): A string containing characters to exclude.\n"
     "  start (int, optional): Starting index (default is 0).\n"
-    "  end (int, optional): Ending index (default is the string length).\n\n"
+    "  end (int, optional): Ending index (default is the string length).\n"
     "Returns:\n"
     "  int: Index of the last non-matching character, or -1 if all match.";
 
@@ -2690,14 +2715,15 @@ static PyObject *Str_split_with_known_callback(PyObject *self, PyObject *args, P
 }
 
 static char const doc_split[] = //
-    "Split a string by a separator.\n\n"
+    "Split a string by a separator.\n"
+    "\n"
     "Args:\n"
-    "  self (Str or str or bytes): The string object.\n"
+    "  text (Str or str or bytes): The string object.\n"
     "  separator (str): The separator to split by (cannot be empty).\n"
     "  maxsplit (int, optional): Maximum number of splits (default is no limit).\n"
-    "  keepseparator (bool, optional): Include the separator in results (default is False).\n\n"
+    "  keepseparator (bool, optional): Include the separator in results (default is False).\n"
     "Returns:\n"
-    "  Strs: A list of strings split by the separator.\n\n"
+    "  Strs: A list of strings split by the separator.\n"
     "Raises:\n"
     "  ValueError: If the separator is an empty string.";
 
@@ -2706,14 +2732,15 @@ static PyObject *Str_split(PyObject *self, PyObject *args, PyObject *kwargs) {
 }
 
 static char const doc_rsplit[] = //
-    "Split a string by a separator starting from the end.\n\n"
+    "Split a string by a separator starting from the end.\n"
+    "\n"
     "Args:\n"
-    "  self (Str or str or bytes): The string object.\n"
+    "  text (Str or str or bytes): The string object.\n"
     "  separator (str): The separator to split by (cannot be empty).\n"
     "  maxsplit (int, optional): Maximum number of splits (default is no limit).\n"
-    "  keepseparator (bool, optional): Include the separator in results (default is False).\n\n"
+    "  keepseparator (bool, optional): Include the separator in results (default is False).\n"
     "Returns:\n"
-    "  Strs: A list of strings split by the separator.\n\n"
+    "  Strs: A list of strings split by the separator.\n"
     "Raises:\n"
     "  ValueError: If the separator is an empty string.";
 
@@ -2722,12 +2749,13 @@ static PyObject *Str_rsplit(PyObject *self, PyObject *args, PyObject *kwargs) {
 }
 
 static char const doc_split_charset[] = //
-    "Split a string by a set of character separators.\n\n"
+    "Split a string by a set of character separators.\n"
+    "\n"
     "Args:\n"
-    "  self (Str or str or bytes): The string object.\n"
+    "  text (Str or str or bytes): The string object.\n"
     "  separators (str): A string containing separator characters.\n"
     "  maxsplit (int, optional): Maximum number of splits (default is no limit).\n"
-    "  keepseparator (bool, optional): Include separators in results (default is False).\n\n"
+    "  keepseparator (bool, optional): Include separators in results (default is False).\n"
     "Returns:\n"
     "  Strs: A list of strings split by the character set.";
 
@@ -2736,12 +2764,13 @@ static PyObject *Str_split_charset(PyObject *self, PyObject *args, PyObject *kwa
 }
 
 static char const doc_rsplit_charset[] = //
-    "Split a string by a set of character separators in reverse order.\n\n"
+    "Split a string by a set of character separators in reverse order.\n"
+    "\n"
     "Args:\n"
-    "  self (Str or str or bytes): The string object.\n"
+    "  text (Str or str or bytes): The string object.\n"
     "  separators (str): A string containing separator characters.\n"
     "  maxsplit (int, optional): Maximum number of splits (default is no limit).\n"
-    "  keepseparator (bool, optional): Include separators in results (default is False).\n\n"
+    "  keepseparator (bool, optional): Include separators in results (default is False).\n"
     "Returns:\n"
     "  Strs: A list of strings split by the character set.";
 
@@ -2750,13 +2779,14 @@ static PyObject *Str_rsplit_charset(PyObject *self, PyObject *args, PyObject *kw
 }
 
 static char const doc_split_iter[] = //
-    "Create an iterator for splitting a string by a separator.\n\n"
+    "Create an iterator for splitting a string by a separator.\n"
+    "\n"
     "Args:\n"
-    "  self (Str or str or bytes): The string object.\n"
+    "  text (Str or str or bytes): The string object.\n"
     "  separator (str): The separator to split by (cannot be empty).\n"
-    "  keepseparator (bool, optional): Include separator in results (default is False).\n\n"
+    "  keepseparator (bool, optional): Include separator in results (default is False).\n"
     "Returns:\n"
-    "  iterator: An iterator yielding split substrings.\n\n"
+    "  iterator: An iterator yielding split substrings.\n"
     "Raises:\n"
     "  ValueError: If the separator is an empty string.";
 
@@ -2765,13 +2795,14 @@ static PyObject *Str_split_iter(PyObject *self, PyObject *args, PyObject *kwargs
 }
 
 static char const doc_rsplit_iter[] = //
-    "Create an iterator for splitting a string by a separator in reverse order.\n\n"
+    "Create an iterator for splitting a string by a separator in reverse order.\n"
+    "\n"
     "Args:\n"
-    "  self (Str or str or bytes): The string object.\n"
+    "  text (Str or str or bytes): The string object.\n"
     "  separator (str): The separator to split by (cannot be empty).\n"
-    "  keepseparator (bool, optional): Include separator in results (default is False).\n\n"
+    "  keepseparator (bool, optional): Include separator in results (default is False).\n"
     "Returns:\n"
-    "  iterator: An iterator yielding split substrings in reverse.\n\n"
+    "  iterator: An iterator yielding split substrings in reverse.\n"
     "Raises:\n"
     "  ValueError: If the separator is an empty string.";
 
@@ -2780,11 +2811,12 @@ static PyObject *Str_rsplit_iter(PyObject *self, PyObject *args, PyObject *kwarg
 }
 
 static char const doc_split_charset_iter[] = //
-    "Create an iterator for splitting a string by a set of character separators.\n\n"
+    "Create an iterator for splitting a string by a set of character separators.\n"
+    "\n"
     "Args:\n"
-    "  self (Str or str or bytes): The string object.\n"
+    "  text (Str or str or bytes): The string object.\n"
     "  separators (str): A string containing separator characters.\n"
-    "  keepseparator (bool, optional): Include separators in results (default is False).\n\n"
+    "  keepseparator (bool, optional): Include separators in results (default is False).\n"
     "Returns:\n"
     "  iterator: An iterator yielding split substrings.";
 
@@ -2793,11 +2825,12 @@ static PyObject *Str_split_charset_iter(PyObject *self, PyObject *args, PyObject
 }
 
 static char const doc_rsplit_charset_iter[] = //
-    "Create an iterator for splitting a string by a set of character separators in reverse order.\n\n"
+    "Create an iterator for splitting a string by a set of character separators in reverse order.\n"
+    "\n"
     "Args:\n"
-    "  self (Str or str or bytes): The string object.\n"
+    "  text (Str or str or bytes): The string object.\n"
     "  separators (str): A string containing separator characters.\n"
-    "  keepseparator (bool, optional): Include separators in results (default is False).\n\n"
+    "  keepseparator (bool, optional): Include separators in results (default is False).\n"
     "Returns:\n"
     "  iterator: An iterator yielding split substrings in reverse.";
 
@@ -2806,11 +2839,12 @@ static PyObject *Str_rsplit_charset_iter(PyObject *self, PyObject *args, PyObjec
 }
 
 static char const doc_splitlines[] = //
-    "Split a string by line breaks.\n\n"
+    "Split a string by line breaks.\n"
+    "\n"
     "Args:\n"
-    "  self (Str or str or bytes): The string object.\n"
+    "  text (Str or str or bytes): The string object.\n"
     "  keeplinebreaks (bool, optional): Include line breaks in the results (default is False).\n"
-    "  maxsplit (int, optional): Maximum number of splits (default is no limit).\n\n"
+    "  maxsplit (int, optional): Maximum number of splits (default is no limit).\n"
     "Returns:\n"
     "  Strs: A list of strings split by line breaks.";
 
@@ -3612,6 +3646,7 @@ static PyMethodDef stringzilla_methods[] = {
     {"endswith", Str_endswith, SZ_METHOD_FLAGS, doc_endswith},
     {"translate", Str_translate, SZ_METHOD_FLAGS, doc_translate},
     {"decode", Str_decode, SZ_METHOD_FLAGS, doc_decode},
+    {"equal", Str_like_equal, SZ_METHOD_FLAGS, doc_like_equal},
 
     // Bidirectional operations
     {"find", Str_find, SZ_METHOD_FLAGS, doc_find},
@@ -3650,7 +3685,7 @@ static PyMethodDef stringzilla_methods[] = {
 
     // Global unary extensions
     {"hash", Str_like_hash, SZ_METHOD_FLAGS, doc_like_hash},
-    {"equal", Str_like_equal, SZ_METHOD_FLAGS, doc_like_equal},
+    {"checksum", Str_like_checksum, SZ_METHOD_FLAGS, doc_like_checksum},
 
     {NULL, NULL, 0, NULL}};
 

--- a/python/lib.c
+++ b/python/lib.c
@@ -714,7 +714,40 @@ static PyObject *Str_like_hash(PyObject *self, PyObject *args, PyObject *kwargs)
     }
 
     sz_u64_t result = sz_hash(text.start, text.length);
-    return PyLong_FromSize_t((size_t)result);
+    return PyLong_FromUnsignedLongLong((unsigned long long)result);
+}
+
+static char const doc_like_checksum[] = //
+    "Compute the checksum of individual byte values in a string.\n"
+    "\n"
+    "This function can be called as a method on a Str object or as a standalone function.\n"
+    "Args:\n"
+    "  text (Str or str or bytes): The string to hash.\n"
+    "Returns:\n"
+    "  int: The checksum of individual byte values in a string.\n"
+    "Raises:\n"
+    "  TypeError: If the argument is not string-like or incorrect number of arguments is provided.";
+
+static PyObject *Str_like_checksum(PyObject *self, PyObject *args, PyObject *kwargs) {
+    // Check minimum arguments
+    int is_member = self != NULL && PyObject_TypeCheck(self, &StrType);
+    Py_ssize_t nargs = PyTuple_Size(args);
+    if (nargs < !is_member || nargs > !is_member + 1 || kwargs) {
+        PyErr_SetString(PyExc_TypeError, "checksum() expects exactly one positional argument");
+        return NULL;
+    }
+
+    PyObject *text_obj = is_member ? self : PyTuple_GET_ITEM(args, 0);
+    sz_string_view_t text;
+
+    // Validate and convert `text`
+    if (!export_string_like(text_obj, &text.start, &text.length)) {
+        wrap_current_exception("The text argument must be string-like");
+        return NULL;
+    }
+
+    sz_u64_t result = sz_checksum(text.start, text.length);
+    return PyLong_FromUnsignedLongLong((unsigned long long)result);
 }
 
 static char const doc_like_equal[] = //

--- a/scripts/bench_token.cpp
+++ b/scripts/bench_token.cpp
@@ -4,6 +4,8 @@
  *
  *  This file is the sibling of `bench_sort.cpp`, `bench_search.cpp` and `bench_similarity.cpp`.
  */
+#include <numeric> // `std::accumulate`
+
 #include <bench.hpp>
 #include <test.hpp> // `random_string`
 
@@ -189,7 +191,7 @@ void bench(strings_type &&strings) {
 
 void bench_on_input_data(int argc, char const **argv) {
     dataset_t dataset = prepare_benchmark_environment(argc, argv);
-
+#if 0
     std::printf("Benchmarking on the entire dataset:\n");
     bench_unary_functions(dataset.tokens, random_generation_functions(100));
     bench_unary_functions(dataset.tokens, random_generation_functions(20));
@@ -211,14 +213,14 @@ void bench_on_input_data(int argc, char const **argv) {
     bench_unary_functions<std::vector<std::string_view>>({dataset.text}, fingerprinting_functions(128, 4 * 1024));
     bench_unary_functions<std::vector<std::string_view>>({dataset.text}, fingerprinting_functions(128, 64 * 1024));
     bench_unary_functions<std::vector<std::string_view>>({dataset.text}, fingerprinting_functions(128, 1024 * 1024));
-
+#endif
     // Baseline benchmarks for real words, coming in all lengths
-    std::printf("Benchmarking on entire dataset:\n");
-    bench<std::vector<std::string_view>>({dataset.text});
-    std::printf("Benchmarking on real lines:\n");
-    bench(dataset.lines);
     std::printf("Benchmarking on real words:\n");
     bench(dataset.tokens);
+    std::printf("Benchmarking on real lines:\n");
+    bench(dataset.lines);
+    std::printf("Benchmarking on entire dataset:\n");
+    bench<std::vector<std::string_view>>({dataset.text});
 
     // Run benchmarks on tokens of different length
     for (std::size_t token_length : {1, 2, 3, 4, 5, 6, 7, 8, 16, 32}) {

--- a/scripts/test.cpp
+++ b/scripts/test.cpp
@@ -1546,12 +1546,10 @@ int main(int argc, char const **argv) {
     std::printf("- Uses NEON: %s \n", SZ_USE_ARM_NEON ? "yes" : "no");
     std::printf("- Uses SVE: %s \n", SZ_USE_ARM_SVE ? "yes" : "no");
 
-#if 0
     // Basic utilities
     test_arithmetical_utilities();
     test_memory_utilities();
     test_replacements();
-#endif
 
 // Compatibility with STL
 #if SZ_DETECT_CPP_17 && __cpp_lib_string_view

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -767,12 +767,22 @@ def test_translations(length: int):
 
 
 @pytest.mark.repeat(3)
-@pytest.mark.parametrize("length", range(1, 300))
+@pytest.mark.parametrize("length", list(range(0, 300)) + [1024, 4096, 100000])
 @pytest.mark.skipif(not numpy_available, reason="NumPy is not installed")
 def test_translations_random(length: int):
     body = get_random_string(length=length)
     lut = np.random.randint(0, 256, size=256, dtype=np.uint8)
     assert sz.translate(body, memoryview(lut)) == baseline_translate(body, lut)
+
+
+@pytest.mark.repeat(3)
+@pytest.mark.parametrize("length", list(range(0, 300)) + [1024, 4096, 100000])
+def test_checksums_random(length: int):
+    def sum_bytes(body: str) -> int:
+        return sum([ord(c) for c in body])
+
+    body = get_random_string(length=length)
+    assert sum_bytes(body) == sz.checksum(body)
 
 
 @pytest.mark.parametrize("list_length", [10, 20, 30, 40, 50])


### PR DESCRIPTION
- 🆕  `sz_checksum(char const *, size_t)` C 99 interface
- 🆕  `sz::str().checksum()` C++ 11 interface
- 🆕  `sz.checksum(str)` Python interface

Database and other Systems Engineers, you can now use StringZilla to dynamically dispatch different check-sum kernels for AVX2 capable Haswell+ CPUs, AVX-512BW capable Ice Lake+ CPUs, and Arm NEON CPUs on mobile. In AVX-512, masked loads are used extensively, resulting in a 10% improvement even on typical English words, averaging 5 bytes in length and __20x performance improvement compared to the serial code for longer strings__.

On the technical side, on x86, the kernels use the well-known `SAD(text, zeros)` idiom to accumulate absolute differences between individual bytes into 64-bit words. It also uses bidirectional traversal to saturate the core, capable of performing 2 loads per CPU cycle. Moreover, on large inputs, it switches to streaming loads, separately handling the head and the tail, similar to our `memcpy` alternative, also outperforming LibC on AVX-512-capable machines 😎 