### PR TITLE
Fix: Add null terminators to character arrays to include final characters

### DIFF
--- a/include/stringzilla/stringzilla.hpp
+++ b/include/stringzilla/stringzilla.hpp
@@ -283,7 +283,7 @@ class basic_charset {
     template <std::size_t count_characters>
     explicit basic_charset(char_type const (&chars)[count_characters]) noexcept : basic_charset() {
         static_assert(count_characters > 0, "Character array cannot be empty");
-        for (std::size_t i = 0; i < count_characters - 1; ++i) { // count_characters - 1 to exclude the null terminator
+        for (std::size_t i = 0; i != count_characters; ++i) {
             char_type c = chars[i];
             bitset_._u64s[sz_bitcast(sz_u8_t, c) >> 6] |= (1ull << (sz_bitcast(sz_u8_t, c) & 63u));
         }
@@ -292,7 +292,7 @@ class basic_charset {
     template <std::size_t count_characters>
     explicit basic_charset(std::array<char_type, count_characters> const &chars) noexcept : basic_charset() {
         static_assert(count_characters > 0, "Character array cannot be empty");
-        for (std::size_t i = 0; i < count_characters - 1; ++i) { // count_characters - 1 to exclude the null terminator
+        for (std::size_t i = 0; i != count_characters; ++i) {
             char_type c = chars[i];
             bitset_._u64s[sz_bitcast(sz_u8_t, c) >> 6] |= (1ull << (sz_bitcast(sz_u8_t, c) & 63u));
         }

--- a/scripts/test.cpp
+++ b/scripts/test.cpp
@@ -137,6 +137,49 @@ static void test_arithmetical_utilities() {
                    (static_cast<sz_u8_t>(number) / static_cast<sz_u8_t>(divisor)));
 }
 
+/**
+ * @brief Tests various ASCII-based methods (e.g., is_alpha, is_digit)
+ *        provided by `sz::string` and `sz::string_view`.
+ */
+template <typename string_type>
+static void test_ascii_utilities() {
+
+    using str = string_type;
+
+    assert(!str("").is_alpha());
+    assert(str("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ").is_alpha());
+    assert(!str("abc9").is_alpha());
+
+    assert(!str("").is_alnum());
+    assert(str("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789").is_alnum());
+    assert(!str("abc!").is_alnum());
+
+    assert(!str("").is_ascii());
+    assert(str("\x00x7F").is_ascii());
+    assert(!str("abc123🔥").is_ascii());
+
+    assert(!str("").is_digit());
+    assert(str("0123456789").is_digit());
+    assert(!str("012a").is_digit());
+
+    assert(!str("").is_lower());
+    assert(str("abcdefghijklmnopqrstuvwxyz").is_lower());
+    assert(!str("abcA").is_lower());
+    assert(!str("abc\n").is_lower());
+
+    assert(!str("").is_space());
+    assert(str(" \t\n\r\f\v").is_space());
+    assert(!str(" \t\r\na").is_space());
+
+    assert(!str("").is_upper());
+    assert(str("ABCDEFGHIJKLMNOPQRSTUVWXYZ").is_upper());
+    assert(!str("ABCa").is_upper());
+
+    assert(!str("").is_printable());
+    assert(str("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!@#$%^&*()_+").is_printable());
+    assert(!str("012\n").is_printable());
+}
+
 inline void expect_equality(char const *a, char const *b, std::size_t size) {
     if (std::memcmp(a, b, size) == 0) return;
     std::size_t mismatch_position = 0;
@@ -1583,6 +1626,8 @@ int main(int argc, char const **argv) {
 
     // Basic utilities
     test_arithmetical_utilities();
+    test_ascii_utilities<sz::string>();
+    test_ascii_utilities<sz::string_view>();
     test_memory_utilities();
     test_replacements();
 

--- a/scripts/test.cpp
+++ b/scripts/test.cpp
@@ -138,8 +138,8 @@ static void test_arithmetical_utilities() {
 }
 
 /**
- * @brief Tests various ASCII-based methods (e.g., is_alpha, is_digit)
- *        provided by `sz::string` and `sz::string_view`.
+ *  @brief  Tests various ASCII-based methods (e.g., `is_alpha`, `is_digit`)
+ *          provided by `sz::string` and `sz::string_view`.
  */
 template <typename string_type>
 static void test_ascii_utilities() {

--- a/scripts/test.cpp
+++ b/scripts/test.cpp
@@ -154,7 +154,7 @@ static void test_ascii_utilities() {
     assert(str("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789").is_alnum());
     assert(!str("abc!").is_alnum());
 
-    assert(!str("").is_ascii());
+    assert(str("").is_ascii());
     assert(str("\x00x7F").is_ascii());
     assert(!str("abc123🔥").is_ascii());
 
@@ -175,9 +175,9 @@ static void test_ascii_utilities() {
     assert(str("ABCDEFGHIJKLMNOPQRSTUVWXYZ").is_upper());
     assert(!str("ABCa").is_upper());
 
-    assert(!str("").is_printable());
+    assert(str("").is_printable());
     assert(str("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!@#$%^&*()_+").is_printable());
-    assert(!str("012\n").is_printable());
+    assert(!str("012🔥").is_printable());
 }
 
 inline void expect_equality(char const *a, char const *b, std::size_t size) {


### PR DESCRIPTION
This PR fixes the issue where the last character of certain character arrays was not included in `basic_charset`. By explicitly adding a `'\0'` terminator to these arrays (e.g., `ascii_letters()`), all intended characters are now properly included.

In addition, new tests have been added for the ASCII utility functions provided by `sz::string` and `sz::string_view`. Previously, these tests would fail due to the missing final character. With this fix, they pass successfully, confirming that the issue is resolved. 

#200 