### PR TITLE
Fix: Correct basic_charset operator

### DIFF
--- a/include/stringzilla/stringzilla.hpp
+++ b/include/stringzilla/stringzilla.hpp
@@ -309,7 +309,7 @@ class basic_charset {
         basic_charset result = *this;
         result.bitset_._u64s[0] |= other.bitset_._u64s[0], result.bitset_._u64s[1] |= other.bitset_._u64s[1],
             result.bitset_._u64s[2] |= other.bitset_._u64s[2], result.bitset_._u64s[3] |= other.bitset_._u64s[3];
-        return *this;
+        return result;
     }
 
     inline basic_charset &add(char_type c) noexcept {


### PR DESCRIPTION
Should have returned `result`.

https://github.com/ashvardanian/StringZilla/blob/645539b468f3c2902061425684d9b002c43a14f7/include/stringzilla/stringzilla.hpp#L308-L312