### PR TITLE
Fixed uninitialized bad shift table

### DIFF
--- a/include/stringzilla/stringzilla.h
+++ b/include/stringzilla/stringzilla.h
@@ -2216,6 +2216,7 @@ SZ_INTERNAL sz_cptr_t _sz_find_horspool_upto_256bytes_serial(sz_cptr_t h_chars, 
         n_length_vec.u64 = n_length;
         n_length_vec.u64 *= 0x0101010101010101ull; // broadcast
         for (sz_size_t i = 0; i != 64; ++i) bad_shift_table.vecs[i].u64 = n_length_vec.u64;
+        for (sz_size_t i = 0; i < n_length; ++i) bad_shift_table.jumps[i] = (sz_u8_t)n_length - 1;
         for (sz_size_t i = 0; i + 1 < n_length; ++i) bad_shift_table.jumps[n[i]] = (sz_u8_t)(n_length - i - 1);
     }
 
@@ -2265,6 +2266,7 @@ SZ_INTERNAL sz_cptr_t _sz_rfind_horspool_upto_256bytes_serial(sz_cptr_t h_chars,
         n_length_vec.u64 = n_length;
         n_length_vec.u64 *= 0x0101010101010101ull; // broadcast
         for (sz_size_t i = 0; i != 64; ++i) bad_shift_table.vecs[i].u64 = n_length_vec.u64;
+        for (sz_size_t i = 0; i < n_length; ++i) bad_shift_table.jumps[i] = (sz_u8_t)n_length - 1;
         for (sz_size_t i = 0; i + 1 < n_length; ++i)
             bad_shift_table.jumps[n[n_length - i - 1]] = (sz_u8_t)(n_length - i - 1);
     }

--- a/include/stringzilla/stringzilla.h
+++ b/include/stringzilla/stringzilla.h
@@ -2216,7 +2216,7 @@ SZ_INTERNAL sz_cptr_t _sz_find_horspool_upto_256bytes_serial(sz_cptr_t h_chars, 
         n_length_vec.u64 = n_length;
         n_length_vec.u64 *= 0x0101010101010101ull; // broadcast
         for (sz_size_t i = 0; i != 64; ++i) bad_shift_table.vecs[i].u64 = n_length_vec.u64;
-        for (sz_size_t i = 0; i < n_length; ++i) bad_shift_table.jumps[i] = (sz_u8_t)n_length - 1;
+        for (sz_size_t i = 0; i < n_length; ++i) bad_shift_table.jumps[i] = (sz_u8_t)(n_length - 1);
         for (sz_size_t i = 0; i + 1 < n_length; ++i) bad_shift_table.jumps[n[i]] = (sz_u8_t)(n_length - i - 1);
     }
 
@@ -2266,7 +2266,7 @@ SZ_INTERNAL sz_cptr_t _sz_rfind_horspool_upto_256bytes_serial(sz_cptr_t h_chars,
         n_length_vec.u64 = n_length;
         n_length_vec.u64 *= 0x0101010101010101ull; // broadcast
         for (sz_size_t i = 0; i != 64; ++i) bad_shift_table.vecs[i].u64 = n_length_vec.u64;
-        for (sz_size_t i = 0; i < n_length; ++i) bad_shift_table.jumps[i] = (sz_u8_t)n_length - 1;
+        for (sz_size_t i = 0; i < n_length; ++i) bad_shift_table.jumps[i] = (sz_u8_t)(n_length - 1);
         for (sz_size_t i = 0; i + 1 < n_length; ++i)
             bad_shift_table.jumps[n[n_length - i - 1]] = (sz_u8_t)(n_length - i - 1);
     }


### PR DESCRIPTION
Fix: Corrected uninitialized bad shift table that could cause an infinite loop if some values were zero in the `_sz_[r]find_horspool_upto_256bytes_serial` methods.

When running the `benchmark_search` with `human_protein_1200row_800len.txt`, the executable would get stuck at `Benchmarking on present lines:` within the `_sz_find_horspool_upto_256bytes_serial` method.  This was because the `i` variable was not incrementing due to a zero value in the shift table.

Tested on Windows 11, Visual Studio 2022, `12th Gen Intel(R) Core(TM) i9-12900H `