### PR TITLE
 use proper offset for last bytes of skylake copy

### DIFF
--- a/include/stringzilla/memory.h
+++ b/include/stringzilla/memory.h
@@ -835,7 +835,7 @@ SZ_PUBLIC void sz_copy_skylake(sz_ptr_t target, sz_cptr_t source, sz_size_t leng
         __mmask64 tail_mask = _sz_u64_mask_until(tail_length);
         _mm512_mask_storeu_epi8(target, head_mask, _mm512_maskz_loadu_epi8(head_mask, source));
         _mm512_mask_storeu_epi8(target + head_length + body_length, tail_mask,
-                                _mm512_maskz_loadu_epi8(tail_mask, source));
+                                _mm512_maskz_loadu_epi8(tail_mask, source + head_length + body_length));
 
         // Now in the main loop, we can use non-temporal loads and stores,
         // performing the operation in both directions.


### PR DESCRIPTION
The bytes at the end of the (larger > 1M) inputs were not properly copied.
