### PR TITLE
alloc test fail --> bugfix due to write to address indicated by pointer was type `char` instead of `sz_size_t`.

### DIFF
--- a/include/stringzilla/types.h
+++ b/include/stringzilla/types.h
@@ -1411,8 +1411,9 @@ SZ_PUBLIC void sz_memory_allocator_init_fixed(sz_memory_allocator_t *alloc, void
     alloc->allocate = (sz_memory_allocate_t)sz_memory_allocate_fixed_;
     alloc->free = (sz_memory_free_t)sz_memory_free_fixed_;
     alloc->handle = buffer;
-    *(sz_size_t *)buffer = length;
-    *((sz_ptr_t)buffer + sizeof(sz_size_t)) = sizeof(sz_size_t) * 2; // The capacity and consumption so far
+    sz_size_t *ptr = (sz_size_t *)buffer;
+    ptr[0] = length;
+    ptr[1] = sizeof(sz_size_t) * 2; // The capacity and consumption so far
 }
 
 SZ_PUBLIC sz_bool_t sz_memory_allocator_equal(sz_memory_allocator_t const *a, sz_memory_allocator_t const *b) {


### PR DESCRIPTION
<sup>(Now filed against the proper dev branch. 😓 )</sup>


Aside: in Win32/MSVC allocated memory is not zeroed, like it is on most Linuxes. This hid the bug (x86/x64 is a little endian machine) till today.

The `assert()` below fails (file: `test_stringzilla.cpp`):

```
void test_memory_allocator_struct() 
...
    // Use a fixed buffer
    {
        char buffer[1024];
        sz_memory_allocator_t alloc;
        sz_memory_allocator_init_fixed(&alloc, buffer, sizeof(buffer));
        void *byte = alloc.allocate(1, alloc.handle);
        assert(byte != nullptr);
        alloc.release(byte, 1, alloc.handle);
    }
```

-->

- first `sz_size_t` should carry length of the block, 1024, which it does.
- second `sz_site_t` should carry the amount consumed to date, which would be 2 `sz_size_t` elements: Win64: 2*8=16, which it didn't due to only one byte written instead of 8.

the `sz_memory_allocator_init_fixed()` call results:
-->
Hexdump of the old block from the MSVC debugger:

```
0x000000088057F490  00 04 00 00 00 00 00 00 10 cc cc cc cc cc cc cc cc cc cc cc cc cc cc ...  
0x000000088057F4DC  cc cc cc cc cc cc cc cc cc cc cc cc cc cc cc cc cc cc cc cc cc cc cc cc ...
```

and here's the new situation after the fix, with values as they should be:

```
0x000000088057F490  00 04 00 00 00 00 00 00 10 00 00 00 00 00 00 00 cc cc cc cc cc cc ...  
0x000000088057F4DC  cc cc cc cc cc cc cc cc cc cc cc cc cc cc cc cc cc cc cc cc cc cc cc cc ...
```
(the 0xCC bytes are the MSVC debug build filling the array on the stack with 'crap' to help discover & diagnose various issues.)

