### PR TITLE
Add: Batch-hashing functionality

### DIFF
--- a/c/stringzilla.c
+++ b/c/stringzilla.c
@@ -63,6 +63,7 @@ typedef struct sz_implementations_t {
 
     sz_sequence_argsort_t sequence_argsort;
     sz_sequence_intersect_t sequence_intersect;
+    sz_sequence_hashes_t sequence_hashes;
     sz_pgrams_sort_t pgrams_sort;
 
 } sz_implementations_t;
@@ -100,6 +101,7 @@ static void sz_dispatch_table_update_implementation_(sz_capability_t caps) {
 
     impl->sequence_argsort = sz_sequence_argsort_serial;
     impl->sequence_intersect = sz_sequence_intersect_serial;
+    impl->sequence_hashes = sz_sequence_hashes_serial;
     impl->pgrams_sort = sz_pgrams_sort_serial;
 
 #if SZ_USE_HASWELL
@@ -169,6 +171,7 @@ static void sz_dispatch_table_update_implementation_(sz_capability_t caps) {
         impl->fill_random = sz_fill_random_ice;
 
         impl->sequence_intersect = sz_sequence_intersect_ice;
+        impl->sequence_hashes = sz_sequence_hashes_ice;
     }
 #endif
 
@@ -220,6 +223,7 @@ static void sz_dispatch_table_update_implementation_(sz_capability_t caps) {
 
         impl->sequence_argsort = sz_sequence_argsort_sve;
         impl->sequence_intersect = sz_sequence_intersect_sve;
+        impl->sequence_hashes = sz_sequence_hashes_sve;
         impl->pgrams_sort = sz_pgrams_sort_sve;
     }
 #endif
@@ -383,6 +387,11 @@ SZ_DYNAMIC sz_status_t sz_sequence_intersect(sz_sequence_t const *first_array, s
                                              sz_size_t *first_positions, sz_size_t *second_positions) {
     return sz_dispatch_table.sequence_intersect(first_array, second_array, alloc, seed, intersection_size,
                                                 first_positions, second_positions);
+}
+
+SZ_DYNAMIC void sz_sequence_hashes(sz_cptr_t const *starts, sz_size_t const *lengths, sz_size_t count, sz_u64_t seed,
+                                  sz_u64_t *hashes) {
+    sz_dispatch_table.sequence_hashes(starts, lengths, count, seed, hashes);
 }
 
 // Provide overrides for the libc mem* functions

--- a/include/stringzilla/types.h
+++ b/include/stringzilla/types.h
@@ -770,6 +770,9 @@ typedef sz_status_t (*sz_sequence_intersect_t)(struct sz_sequence_t const *, str
                                                sz_memory_allocator_t *, sz_u64_t, sz_size_t *, sz_sorted_idx_t *,
                                                sz_sorted_idx_t *);
 
+/** @brief Signature of `sz_sequence_hashes`. */
+typedef void (*sz_sequence_hashes_t)(sz_cptr_t const *, sz_size_t const *, sz_size_t, sz_u64_t, sz_u64_t *);
+
 #pragma endregion
 
 #pragma region Helper Structures

--- a/rust/stringzilla.rs
+++ b/rust/stringzilla.rs
@@ -239,6 +239,14 @@ extern "C" {
         second_positions: *mut SortedIdx,
     ) -> Status;
 
+    pub(crate) fn sz_sequence_hashes(
+        starts: *const *const u8,
+        lengths: *const usize,
+        count: usize,
+        seed: u64,
+        hashes: *mut u64,
+    );
+
 }
 
 impl SemVer {
@@ -680,6 +688,134 @@ where
 {
     hash_with_seed(text, 0)
 }
+
+/// Iterator adapter that computes hashes in batches for efficiency.
+/// Uses SIMD-accelerated batch hashing for strings ≤16 bytes.
+pub struct SzHashes<I, const BATCH_SIZE: usize = 32>
+where
+    I: Iterator,
+    I::Item: AsRef<[u8]>,
+{
+    source: I,
+    seed: u64,
+    items: [Option<I::Item>; BATCH_SIZE],
+    starts: [*const u8; BATCH_SIZE],
+    lengths: [usize; BATCH_SIZE],
+    hashes: [u64; BATCH_SIZE],
+    batch_len: usize,
+    batch_pos: usize,
+}
+
+impl<I, const BATCH_SIZE: usize> SzHashes<I, BATCH_SIZE>
+where
+    I: Iterator,
+    I::Item: AsRef<[u8]>,
+{
+    fn new(source: I, seed: u64) -> Self {
+        Self {
+            source,
+            seed,
+            items: core::array::from_fn(|_| None),
+            starts: [core::ptr::null(); BATCH_SIZE],
+            lengths: [0; BATCH_SIZE],
+            hashes: [0; BATCH_SIZE],
+            batch_len: 0,
+            batch_pos: 0,
+        }
+    }
+
+    fn fill_batch(&mut self) -> bool {
+        self.batch_len = 0;
+        self.batch_pos = 0;
+
+        // Collect batch of items and extract pointers upfront
+        for i in 0..BATCH_SIZE {
+            self.items[i] = self.source.next();
+            if let Some(ref item) = self.items[i] {
+                let slice = item.as_ref();
+                self.starts[i] = slice.as_ptr();
+                self.lengths[i] = slice.len();
+                self.batch_len += 1;
+            } else {
+                break;
+            }
+        }
+
+        if self.batch_len > 0 {
+            // Call C function directly with pointer arrays - no callbacks!
+            unsafe {
+                sz_sequence_hashes(
+                    self.starts.as_ptr(),
+                    self.lengths.as_ptr(),
+                    self.batch_len,
+                    self.seed,
+                    self.hashes.as_mut_ptr(),
+                );
+            }
+            true
+        } else {
+            false
+        }
+    }
+}
+
+impl<I, const BATCH_SIZE: usize> Iterator for SzHashes<I, BATCH_SIZE>
+where
+    I: Iterator,
+    I::Item: AsRef<[u8]>,
+{
+    type Item = u64;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.batch_pos >= self.batch_len {
+            if !self.fill_batch() {
+                return None;
+            }
+        }
+
+        let hash = self.hashes[self.batch_pos];
+        self.batch_pos += 1;
+        Some(hash)
+    }
+}
+
+/// Extension trait for iterator-based batched hashing.
+pub trait SzHashExt: Iterator {
+    /// Compute hashes for iterator items in batches for efficiency.
+    /// Uses default batch size of 32.
+    ///
+    /// # Examples
+    /// ```
+    /// use stringzilla::stringzilla::SzHashExt;
+    /// let strings = vec!["apple", "banana", "cherry"];
+    /// let hashes: Vec<u64> = strings.iter().sz_hashes(0).collect();
+    /// ```
+    fn sz_hashes(self, seed: u64) -> SzHashes<Self, 32>
+    where
+        Self: Sized,
+        Self::Item: AsRef<[u8]>,
+    {
+        SzHashes::new(self, seed)
+    }
+
+    /// Compute hashes for iterator items in batches with custom batch size.
+    ///
+    /// # Examples
+    /// ```
+    /// use stringzilla::stringzilla::SzHashExt;
+    /// let strings = vec!["apple", "banana", "cherry"];
+    /// let hashes: Vec<u64> = strings.iter().sz_hashes_with_batch_size::<64>(0).collect();
+    /// ```
+    fn sz_hashes_with_batch_size<const BATCH_SIZE: usize>(self, seed: u64) -> SzHashes<Self, BATCH_SIZE>
+    where
+        Self: Sized,
+        Self::Item: AsRef<[u8]>,
+    {
+        SzHashes::new(self, seed)
+    }
+}
+
+impl<I> SzHashExt for I where I: Iterator {}
 
 /// Locates the first matching substring within `haystack` that equals `needle`.
 /// This function is similar to the `memmem()` function in LibC, but, unlike `strstr()`,
@@ -1882,6 +2018,37 @@ mod tests {
                 sz::hash_with_seed("HelloWorld", *seed)
             );
         }
+    }
+
+    #[test]
+    fn batched_hashing() {
+        use crate::stringzilla::SzHashExt;
+
+        let strings = vec!["apple", "banana", "cherry", "date", "elderberry"];
+
+        // Compute hashes using batched iterator with default batch size
+        let batched_hashes: Vec<u64> = strings.iter().sz_hashes(0).collect();
+
+        // Compute hashes individually for comparison
+        let individual_hashes: Vec<u64> = strings.iter().map(|s| sz::hash(s)).collect();
+
+        // They should match
+        assert_eq!(batched_hashes.len(), individual_hashes.len());
+        for (batched, individual) in batched_hashes.iter().zip(individual_hashes.iter()) {
+            assert_eq!(batched, individual);
+        }
+
+        // Test with custom batch size
+        let batched_hashes_2: Vec<u64> = strings.iter().sz_hashes_with_batch_size::<2>(0).collect();
+        assert_eq!(batched_hashes, batched_hashes_2);
+
+        // Test with seed
+        let batched_hashes_seed: Vec<u64> = strings.iter().sz_hashes(42).collect();
+        let individual_hashes_seed: Vec<u64> = strings.iter().map(|s| sz::hash_with_seed(s, 42)).collect();
+        assert_eq!(batched_hashes_seed, individual_hashes_seed);
+
+        // Different seeds should produce different hashes
+        assert_ne!(batched_hashes, batched_hashes_seed);
     }
 
     #[test]


### PR DESCRIPTION
Sadly, I don't currently see a good general-purpose method to leverage batch-capable hashing. All of my attempts to wrap it - come with overly expensive control-flow. Would be great to find a cheaper way to expose it to C and Rust, to use for faster parallel `hashbrown::HashMap<String, _>` construction.