### PR TITLE
Intel Westmere Kernels

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@
 # Tests for different SIMD architectures:
 #
 # * stringzilla_test_cpp20_serial: A test executable for serial execution.
-# * stringzilla_test_cpp20_nehalem: A test executable for SSE4.2.
+# * stringzilla_test_cpp20_westmere: A test executable for SSE4.2.
 # * stringzilla_test_cpp20_haswell: A test executable for AVX2.
 # * stringzilla_test_cpp20_ice: A test executable for AVX-512.
 # * stringzilla_test_cpp20_neon: A test executable for ARM Neon.
@@ -441,23 +441,23 @@ if (STRINGZILLA_BUILD_TEST)
         # x86 specific backends
         if (MSVC)
             define_launcher(stringzilla_test_cpp20_serial scripts/test_stringzilla.cpp 20 "AVX")
-            define_launcher(stringzilla_test_cpp20_nehalem scripts/test_stringzilla.cpp 20 "SSE4.2")
+            define_launcher(stringzilla_test_cpp20_westmere scripts/test_stringzilla.cpp 20 "SSE4.2")
             define_launcher(stringzilla_test_cpp20_haswell scripts/test_stringzilla.cpp 20 "AVX2")
             define_launcher(stringzilla_test_cpp20_ice scripts/test_stringzilla.cpp 20 "AVX512")
             if (STRINGZILLA_BUILD_CUDA)
                 define_gpu_launcher(stringzillas_test_cu20_serial scripts/test_stringzillas.cu 20 "AVX")
-                define_gpu_launcher(stringzillas_test_cu20_nehalem scripts/test_stringzillas.cu 20 "SSE4.2")
+                define_gpu_launcher(stringzillas_test_cu20_westmere scripts/test_stringzillas.cu 20 "SSE4.2")
                 define_gpu_launcher(stringzillas_test_cu20_haswell scripts/test_stringzillas.cu 20 "AVX2")
                 define_gpu_launcher(stringzillas_test_cu20_ice scripts/test_stringzillas.cu 20 "AVX512")
             endif ()
         else ()
             define_launcher(stringzilla_test_cpp20_serial scripts/test_stringzilla.cpp 20 "ivybridge")
-            define_launcher(stringzilla_test_cpp20_nehalem scripts/test_stringzilla.cpp 20 "nehalem")
+            define_launcher(stringzilla_test_cpp20_westmere scripts/test_stringzilla.cpp 20 "westmere")
             define_launcher(stringzilla_test_cpp20_haswell scripts/test_stringzilla.cpp 20 "haswell")
             define_launcher(stringzilla_test_cpp20_ice scripts/test_stringzilla.cpp 20 "sapphirerapids")
             if (STRINGZILLA_BUILD_CUDA)
                 define_gpu_launcher(stringzillas_test_cu20_serial scripts/test_stringzillas.cu 20 "ivybridge")
-                define_gpu_launcher(stringzillas_test_cu20_nehalem scripts/test_stringzillas.cu 20 "nehalem")
+                define_gpu_launcher(stringzillas_test_cu20_westmere scripts/test_stringzillas.cu 20 "westmere")
                 define_gpu_launcher(stringzillas_test_cu20_haswell scripts/test_stringzillas.cu 20 "haswell")
                 define_gpu_launcher(stringzillas_test_cu20_ice scripts/test_stringzillas.cu 20 "sapphirerapids")
             endif ()
@@ -509,14 +509,14 @@ if (STRINGZILLA_BUILD_SHARED)
             endif ()
 
             target_compile_definitions(
-                ${target} PRIVATE "SZ_USE_NEHALEM=1" "SZ_USE_HASWELL=1" "SZ_USE_SKYLAKE=1" "SZ_USE_ICE=1"
+                ${target} PRIVATE "SZ_USE_WESTMERE=1" "SZ_USE_HASWELL=1" "SZ_USE_SKYLAKE=1" "SZ_USE_ICE=1"
                                   "SZ_USE_NEON=0" "SZ_USE_SVE=0" "SZ_USE_SVE2=0"
             )
         elseif (SZ_PLATFORM_ARM)
             set_compiler_flags(${target} "" "armv8-a" "${CMAKE_CXX_COMPILER_ID}")
 
             target_compile_definitions(
-                ${target} PRIVATE "SZ_USE_NEHALEM=0" "SZ_USE_HASWELL=0" "SZ_USE_SKYLAKE=0" "SZ_USE_ICE=0" "SZ_USE_NEON=1"
+                ${target} PRIVATE "SZ_USE_WESTMERE=0" "SZ_USE_HASWELL=0" "SZ_USE_SKYLAKE=0" "SZ_USE_ICE=0" "SZ_USE_NEON=1"
                                   "SZ_USE_SVE=1" "SZ_USE_SVE2=1"
             )
         endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@
 # Tests for different SIMD architectures:
 #
 # * stringzilla_test_cpp20_serial: A test executable for serial execution.
+# * stringzilla_test_cpp20_nehalem: A test executable for SSE4.2.
 # * stringzilla_test_cpp20_haswell: A test executable for AVX2.
 # * stringzilla_test_cpp20_ice: A test executable for AVX-512.
 # * stringzilla_test_cpp20_neon: A test executable for ARM Neon.
@@ -440,19 +441,23 @@ if (STRINGZILLA_BUILD_TEST)
         # x86 specific backends
         if (MSVC)
             define_launcher(stringzilla_test_cpp20_serial scripts/test_stringzilla.cpp 20 "AVX")
+            define_launcher(stringzilla_test_cpp20_nehalem scripts/test_stringzilla.cpp 20 "SSE4.2")
             define_launcher(stringzilla_test_cpp20_haswell scripts/test_stringzilla.cpp 20 "AVX2")
             define_launcher(stringzilla_test_cpp20_ice scripts/test_stringzilla.cpp 20 "AVX512")
             if (STRINGZILLA_BUILD_CUDA)
                 define_gpu_launcher(stringzillas_test_cu20_serial scripts/test_stringzillas.cu 20 "AVX")
+                define_gpu_launcher(stringzillas_test_cu20_nehalem scripts/test_stringzillas.cu 20 "SSE4.2")
                 define_gpu_launcher(stringzillas_test_cu20_haswell scripts/test_stringzillas.cu 20 "AVX2")
                 define_gpu_launcher(stringzillas_test_cu20_ice scripts/test_stringzillas.cu 20 "AVX512")
             endif ()
         else ()
             define_launcher(stringzilla_test_cpp20_serial scripts/test_stringzilla.cpp 20 "ivybridge")
+            define_launcher(stringzilla_test_cpp20_nehalem scripts/test_stringzilla.cpp 20 "nehalem")
             define_launcher(stringzilla_test_cpp20_haswell scripts/test_stringzilla.cpp 20 "haswell")
             define_launcher(stringzilla_test_cpp20_ice scripts/test_stringzilla.cpp 20 "sapphirerapids")
             if (STRINGZILLA_BUILD_CUDA)
                 define_gpu_launcher(stringzillas_test_cu20_serial scripts/test_stringzillas.cu 20 "ivybridge")
+                define_gpu_launcher(stringzillas_test_cu20_nehalem scripts/test_stringzillas.cu 20 "nehalem")
                 define_gpu_launcher(stringzillas_test_cu20_haswell scripts/test_stringzillas.cu 20 "haswell")
                 define_gpu_launcher(stringzillas_test_cu20_ice scripts/test_stringzillas.cu 20 "sapphirerapids")
             endif ()
@@ -504,15 +509,15 @@ if (STRINGZILLA_BUILD_SHARED)
             endif ()
 
             target_compile_definitions(
-                ${target} PRIVATE "SZ_USE_HASWELL=1" "SZ_USE_SKYLAKE=1" "SZ_USE_ICE=1" "SZ_USE_NEON=0" "SZ_USE_SVE=0"
-                                  "SZ_USE_SVE2=0"
+                ${target} PRIVATE "SZ_USE_NEHALEM=1" "SZ_USE_HASWELL=1" "SZ_USE_SKYLAKE=1" "SZ_USE_ICE=1"
+                                  "SZ_USE_NEON=0" "SZ_USE_SVE=0" "SZ_USE_SVE2=0"
             )
         elseif (SZ_PLATFORM_ARM)
             set_compiler_flags(${target} "" "armv8-a" "${CMAKE_CXX_COMPILER_ID}")
 
             target_compile_definitions(
-                ${target} PRIVATE "SZ_USE_HASWELL=0" "SZ_USE_SKYLAKE=0" "SZ_USE_ICE=0" "SZ_USE_NEON=1" "SZ_USE_SVE=1"
-                                  "SZ_USE_SVE2=1"
+                ${target} PRIVATE "SZ_USE_NEHALEM=0" "SZ_USE_HASWELL=0" "SZ_USE_SKYLAKE=0" "SZ_USE_ICE=0" "SZ_USE_NEON=1"
+                                  "SZ_USE_SVE=1" "SZ_USE_SVE2=1"
             )
         endif ()
 

--- a/README.md
+++ b/README.md
@@ -745,6 +745,7 @@ sz_size_t substring_position = ptr ? (sz_size_t)(ptr - haystack.start) : SZ_SIZE
 // Backend-specific variants return pointers as well
 sz_cptr_t ptr = sz_find_skylake(haystack.start, haystack.length, needle.start, needle.length);
 sz_cptr_t ptr = sz_find_haswell(haystack.start, haystack.length, needle.start, needle.length);
+sz_cptr_t ptr = sz_find_nehalem(haystack.start, haystack.length, needle.start, needle.length);
 sz_cptr_t ptr = sz_find_neon(haystack.start, haystack.length, needle.start, needle.length);
 
 // Hash strings at once
@@ -1415,7 +1416,7 @@ __`SZ_DEBUG`__:
 > If you want to enable more aggressive bounds-checking, define `SZ_DEBUG` before including the header.
 > If not explicitly set, it will be inferred from the build type.
 
-__`SZ_USE_HASWELL`, `SZ_USE_SKYLAKE`, `SZ_USE_ICE`, `SZ_USE_NEON`, `SZ_USE_NEON_AES`, `SZ_USE_SVE`, `SZ_USE_SVE2`, `SZ_USE_SVE2_AES`__:
+__`SZ_USE_NEHALEM`, `SZ_USE_HASWELL`, `SZ_USE_SKYLAKE`, `SZ_USE_ICE`, `SZ_USE_NEON`, `SZ_USE_NEON_AES`, `SZ_USE_SVE`, `SZ_USE_SVE2`, `SZ_USE_SVE2_AES`__:
 
 > One can explicitly disable certain families of SIMD instructions for compatibility purposes.
 > Default values are inferred at compile time depending on compiler support (for dynamic dispatch) and the target architecture (for static dispatch).
@@ -2181,6 +2182,7 @@ Use it to guarantee constant performance, or to explore how different algorithms
 
 ```c
 sz_find(text, length, pattern, 3);          // Auto-dispatch
+sz_find_nehalem(text, length, pattern, 3);  // Intel Nehalem+ SSE4.2
 sz_find_haswell(text, length, pattern, 3);  // Intel Haswell+ AVX2
 sz_find_skylake(text, length, pattern, 3);  // Intel Skylake+ AVX-512
 sz_find_neon(text, length, pattern, 3);     // Arm NEON 128-bit
@@ -2191,7 +2193,7 @@ StringZilla automatically picks the most advanced backend for the given CPU.
 Similarly, in Python, you can log the auto-detected capabilities:
 
 ```python
-python -c "import stringzilla; print(stringzilla.__capabilities__)"         # ('serial', 'haswell', 'skylake', 'ice', 'neon', 'sve', 'sve2+aes')
+python -c "import stringzilla; print(stringzilla.__capabilities__)"         # ('serial', 'nehalem', 'haswell', 'skylake', 'ice', 'neon', 'sve', 'sve2+aes')
 python -c "import stringzilla; print(stringzilla.__capabilities_str__)"     # "haswell, skylake, ice, neon, sve, sve2+aes"
 ```
 

--- a/README.md
+++ b/README.md
@@ -745,7 +745,7 @@ sz_size_t substring_position = ptr ? (sz_size_t)(ptr - haystack.start) : SZ_SIZE
 // Backend-specific variants return pointers as well
 sz_cptr_t ptr = sz_find_skylake(haystack.start, haystack.length, needle.start, needle.length);
 sz_cptr_t ptr = sz_find_haswell(haystack.start, haystack.length, needle.start, needle.length);
-sz_cptr_t ptr = sz_find_nehalem(haystack.start, haystack.length, needle.start, needle.length);
+sz_cptr_t ptr = sz_find_westmere(haystack.start, haystack.length, needle.start, needle.length);
 sz_cptr_t ptr = sz_find_neon(haystack.start, haystack.length, needle.start, needle.length);
 
 // Hash strings at once
@@ -1416,7 +1416,7 @@ __`SZ_DEBUG`__:
 > If you want to enable more aggressive bounds-checking, define `SZ_DEBUG` before including the header.
 > If not explicitly set, it will be inferred from the build type.
 
-__`SZ_USE_NEHALEM`, `SZ_USE_HASWELL`, `SZ_USE_SKYLAKE`, `SZ_USE_ICE`, `SZ_USE_NEON`, `SZ_USE_NEON_AES`, `SZ_USE_SVE`, `SZ_USE_SVE2`, `SZ_USE_SVE2_AES`__:
+__`SZ_USE_WESTMERE`, `SZ_USE_HASWELL`, `SZ_USE_SKYLAKE`, `SZ_USE_ICE`, `SZ_USE_NEON`, `SZ_USE_NEON_AES`, `SZ_USE_SVE`, `SZ_USE_SVE2`, `SZ_USE_SVE2_AES`__:
 
 > One can explicitly disable certain families of SIMD instructions for compatibility purposes.
 > Default values are inferred at compile time depending on compiler support (for dynamic dispatch) and the target architecture (for static dispatch).
@@ -2182,7 +2182,7 @@ Use it to guarantee constant performance, or to explore how different algorithms
 
 ```c
 sz_find(text, length, pattern, 3);          // Auto-dispatch
-sz_find_nehalem(text, length, pattern, 3);  // Intel Nehalem+ SSE4.2
+sz_find_westmere(text, length, pattern, 3);  // Intel Westmere+ SSE4.2
 sz_find_haswell(text, length, pattern, 3);  // Intel Haswell+ AVX2
 sz_find_skylake(text, length, pattern, 3);  // Intel Skylake+ AVX-512
 sz_find_neon(text, length, pattern, 3);     // Arm NEON 128-bit
@@ -2193,7 +2193,7 @@ StringZilla automatically picks the most advanced backend for the given CPU.
 Similarly, in Python, you can log the auto-detected capabilities:
 
 ```python
-python -c "import stringzilla; print(stringzilla.__capabilities__)"         # ('serial', 'nehalem', 'haswell', 'skylake', 'ice', 'neon', 'sve', 'sve2+aes')
+python -c "import stringzilla; print(stringzilla.__capabilities__)"         # ('serial', 'westmere', 'haswell', 'skylake', 'ice', 'neon', 'sve', 'sve2+aes')
 python -c "import stringzilla; print(stringzilla.__capabilities_str__)"     # "haswell, skylake, ice, neon, sve, sve2+aes"
 ```
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -29,6 +29,7 @@
                 "target_arch=='x64'",
                 {
                   "defines": [
+                    "SZ_USE_NEHALEM=1",
                     "SZ_USE_HASWELL=1",
                     "SZ_USE_SKYLAKE=1",
                     "SZ_USE_ICE=1",
@@ -42,6 +43,7 @@
                 "target_arch=='arm64'",
                 {
                   "defines": [
+                    "SZ_USE_NEHALEM=0",
                     "SZ_USE_HASWELL=0",
                     "SZ_USE_SKYLAKE=0",
                     "SZ_USE_ICE=0",
@@ -64,6 +66,7 @@
                 "target_arch=='x64'",
                 {
                   "defines": [
+                    "SZ_USE_NEHALEM=1",
                     "SZ_USE_HASWELL=1",
                     "SZ_USE_SKYLAKE=0",
                     "SZ_USE_ICE=0",
@@ -77,6 +80,7 @@
                 "target_arch=='arm64'",
                 {
                   "defines": [
+                    "SZ_USE_NEHALEM=0",
                     "SZ_USE_HASWELL=0",
                     "SZ_USE_SKYLAKE=0",
                     "SZ_USE_ICE=0",
@@ -98,6 +102,7 @@
                 "target_arch=='x64'",
                 {
                   "defines": [
+                    "SZ_USE_NEHALEM=1",
                     "SZ_USE_HASWELL=1",
                     "SZ_USE_SKYLAKE=1",
                     "SZ_USE_ICE=1",
@@ -111,6 +116,7 @@
                 "target_arch=='arm64'",
                 {
                   "defines": [
+                    "SZ_USE_NEHALEM=0",
                     "SZ_USE_HASWELL=0",
                     "SZ_USE_SKYLAKE=0",
                     "SZ_USE_ICE=0",

--- a/binding.gyp
+++ b/binding.gyp
@@ -29,7 +29,7 @@
                 "target_arch=='x64'",
                 {
                   "defines": [
-                    "SZ_USE_NEHALEM=1",
+                    "SZ_USE_WESTMERE=1",
                     "SZ_USE_HASWELL=1",
                     "SZ_USE_SKYLAKE=1",
                     "SZ_USE_ICE=1",
@@ -43,7 +43,7 @@
                 "target_arch=='arm64'",
                 {
                   "defines": [
-                    "SZ_USE_NEHALEM=0",
+                    "SZ_USE_WESTMERE=0",
                     "SZ_USE_HASWELL=0",
                     "SZ_USE_SKYLAKE=0",
                     "SZ_USE_ICE=0",
@@ -66,7 +66,7 @@
                 "target_arch=='x64'",
                 {
                   "defines": [
-                    "SZ_USE_NEHALEM=1",
+                    "SZ_USE_WESTMERE=1",
                     "SZ_USE_HASWELL=1",
                     "SZ_USE_SKYLAKE=0",
                     "SZ_USE_ICE=0",
@@ -80,7 +80,7 @@
                 "target_arch=='arm64'",
                 {
                   "defines": [
-                    "SZ_USE_NEHALEM=0",
+                    "SZ_USE_WESTMERE=0",
                     "SZ_USE_HASWELL=0",
                     "SZ_USE_SKYLAKE=0",
                     "SZ_USE_ICE=0",
@@ -102,7 +102,7 @@
                 "target_arch=='x64'",
                 {
                   "defines": [
-                    "SZ_USE_NEHALEM=1",
+                    "SZ_USE_WESTMERE=1",
                     "SZ_USE_HASWELL=1",
                     "SZ_USE_SKYLAKE=1",
                     "SZ_USE_ICE=1",
@@ -116,7 +116,7 @@
                 "target_arch=='arm64'",
                 {
                   "defines": [
-                    "SZ_USE_NEHALEM=0",
+                    "SZ_USE_WESTMERE=0",
                     "SZ_USE_HASWELL=0",
                     "SZ_USE_SKYLAKE=0",
                     "SZ_USE_ICE=0",

--- a/build.rs
+++ b/build.rs
@@ -81,7 +81,7 @@ fn build_stringzilla() -> HashMap<String, bool> {
             "SZ_USE_ICE",
             "SZ_USE_SKYLAKE",
             "SZ_USE_HASWELL",
-            "SZ_USE_NEHALEM",
+            "SZ_USE_WESTMERE",
         ],
         _ => vec![],
     };

--- a/build.rs
+++ b/build.rs
@@ -81,6 +81,7 @@ fn build_stringzilla() -> HashMap<String, bool> {
             "SZ_USE_ICE",
             "SZ_USE_SKYLAKE",
             "SZ_USE_HASWELL",
+            "SZ_USE_NEHALEM",
         ],
         _ => vec![],
     };

--- a/c/stringzilla.c
+++ b/c/stringzilla.c
@@ -102,6 +102,18 @@ static void sz_dispatch_table_update_implementation_(sz_capability_t caps) {
     impl->sequence_intersect = sz_sequence_intersect_serial;
     impl->pgrams_sort = sz_pgrams_sort_serial;
 
+#if SZ_USE_NEHALEM
+    if (caps & sz_cap_nehalem_k) {
+        impl->equal = sz_equal_nehalem;
+        impl->order = sz_order_nehalem;
+
+        impl->find_byte = sz_find_byte_nehalem;
+        impl->rfind_byte = sz_rfind_byte_nehalem;
+        impl->find = sz_find_nehalem;
+        impl->rfind = sz_rfind_nehalem;
+    }
+#endif
+
 #if SZ_USE_HASWELL
     if (caps & sz_cap_haswell_k) {
         impl->equal = sz_equal_haswell;

--- a/c/stringzilla.c
+++ b/c/stringzilla.c
@@ -102,15 +102,15 @@ static void sz_dispatch_table_update_implementation_(sz_capability_t caps) {
     impl->sequence_intersect = sz_sequence_intersect_serial;
     impl->pgrams_sort = sz_pgrams_sort_serial;
 
-#if SZ_USE_NEHALEM
-    if (caps & sz_cap_nehalem_k) {
-        impl->equal = sz_equal_nehalem;
-        impl->order = sz_order_nehalem;
+#if SZ_USE_WESTMERE
+    if (caps & sz_cap_westmere_k) {
+        impl->equal = sz_equal_westmere;
+        impl->order = sz_order_westmere;
 
-        impl->find_byte = sz_find_byte_nehalem;
-        impl->rfind_byte = sz_rfind_byte_nehalem;
-        impl->find = sz_find_nehalem;
-        impl->rfind = sz_rfind_nehalem;
+        impl->find_byte = sz_find_byte_westmere;
+        impl->rfind_byte = sz_rfind_byte_westmere;
+        impl->find = sz_find_westmere;
+        impl->rfind = sz_rfind_westmere;
     }
 #endif
 

--- a/c/stringzilla.c
+++ b/c/stringzilla.c
@@ -107,6 +107,12 @@ static void sz_dispatch_table_update_implementation_(sz_capability_t caps) {
         impl->equal = sz_equal_westmere;
         impl->order = sz_order_westmere;
 
+        impl->hash = sz_hash_westmere;
+        impl->hash_state_init = sz_hash_state_init_westmere;
+        impl->hash_state_update = sz_hash_state_update_westmere;
+        impl->hash_state_digest = sz_hash_state_digest_westmere;
+        impl->fill_random = sz_fill_random_westmere;
+
         impl->find_byte = sz_find_byte_westmere;
         impl->rfind_byte = sz_rfind_byte_westmere;
         impl->find = sz_find_westmere;
@@ -125,11 +131,6 @@ static void sz_dispatch_table_update_implementation_(sz_capability_t caps) {
         impl->lookup = sz_lookup_haswell;
 
         impl->bytesum = sz_bytesum_haswell;
-        impl->hash = sz_hash_haswell;
-        impl->hash_state_init = sz_hash_state_init_haswell;
-        impl->hash_state_update = sz_hash_state_update_haswell;
-        impl->hash_state_digest = sz_hash_state_digest_haswell;
-        impl->fill_random = sz_fill_random_haswell;
 
         impl->find_byte = sz_find_byte_haswell;
         impl->rfind_byte = sz_rfind_byte_haswell;

--- a/include/stringzilla/compare.h
+++ b/include/stringzilla/compare.h
@@ -90,11 +90,11 @@ SZ_PUBLIC sz_bool_t sz_equal_serial(sz_cptr_t a, sz_cptr_t b, sz_size_t length);
 /** @copydoc sz_order */
 SZ_PUBLIC sz_ordering_t sz_order_serial(sz_cptr_t a, sz_size_t a_length, sz_cptr_t b, sz_size_t b_length);
 
-#if SZ_USE_NEHALEM
+#if SZ_USE_WESTMERE
 /** @copydoc sz_equal */
-SZ_PUBLIC sz_bool_t sz_equal_nehalem(sz_cptr_t a, sz_cptr_t b, sz_size_t length);
+SZ_PUBLIC sz_bool_t sz_equal_westmere(sz_cptr_t a, sz_cptr_t b, sz_size_t length);
 /** @copydoc sz_order */
-SZ_PUBLIC sz_ordering_t sz_order_nehalem(sz_cptr_t a, sz_size_t a_length, sz_cptr_t b, sz_size_t b_length);
+SZ_PUBLIC sz_ordering_t sz_order_westmere(sz_cptr_t a, sz_size_t a_length, sz_cptr_t b, sz_size_t b_length);
 #endif
 
 #if SZ_USE_HASWELL
@@ -120,11 +120,11 @@ SZ_PUBLIC sz_ordering_t sz_order_neon(sz_cptr_t a, sz_size_t a_length, sz_cptr_t
 
 #pragma endregion // Core API
 
-/* SSE implementation of the string search algorithms for Nehalem processors and newer.
+/* SSE implementation of the string search algorithms for Westmere processors and newer.
  *  Very minimalistic (compared to AVX-512), but still faster than the serial implementation.
  */
-#pragma region Nehalem Implementation
-#if SZ_USE_NEHALEM
+#pragma region Westmere Implementation
+#if SZ_USE_WESTMERE
 #if defined(__clang__)
 #pragma clang attribute push(__attribute__((target("sse4.2"))), apply_to = function)
 #elif defined(__GNUC__)
@@ -132,13 +132,13 @@ SZ_PUBLIC sz_ordering_t sz_order_neon(sz_cptr_t a, sz_size_t a_length, sz_cptr_t
 #pragma GCC target("sse4.2")
 #endif
 
-SZ_PUBLIC sz_ordering_t sz_order_nehalem(sz_cptr_t a, sz_size_t a_length, sz_cptr_t b, sz_size_t b_length) {
+SZ_PUBLIC sz_ordering_t sz_order_westmere(sz_cptr_t a, sz_size_t a_length, sz_cptr_t b, sz_size_t b_length) {
     //! Before optimizing this, read the "Operations Not Worth Optimizing" in Contributions Guide:
     //! https://github.com/ashvardanian/StringZilla/blob/main/CONTRIBUTING.md#general-performance-observations
     return sz_order_serial(a, a_length, b, b_length);
 }
 
-SZ_PUBLIC sz_bool_t sz_equal_nehalem(sz_cptr_t a, sz_cptr_t b, sz_size_t length) {
+SZ_PUBLIC sz_bool_t sz_equal_westmere(sz_cptr_t a, sz_cptr_t b, sz_size_t length) {
     if (length < 8) {
         sz_cptr_t const a_end = a + length;
         while (a != a_end && *a == *b) a++, b++;
@@ -188,8 +188,8 @@ SZ_PUBLIC sz_bool_t sz_equal_nehalem(sz_cptr_t a, sz_cptr_t b, sz_size_t length)
 #elif defined(__GNUC__)
 #pragma GCC pop_options
 #endif
-#endif            // SZ_USE_NEHALEM
-#pragma endregion // Nehalem Implementation
+#endif            // SZ_USE_WESTMERE
+#pragma endregion // Westmere Implementation
 
 #pragma region Serial Implementation
 

--- a/include/stringzilla/find.h
+++ b/include/stringzilla/find.h
@@ -60,11 +60,11 @@ SZ_PUBLIC sz_cptr_t sz_find_byte_serial(sz_cptr_t haystack, sz_size_t h_length, 
 /** @copydoc sz_rfind_byte */
 SZ_PUBLIC sz_cptr_t sz_rfind_byte_serial(sz_cptr_t haystack, sz_size_t h_length, sz_cptr_t needle);
 
-#if SZ_USE_NEHALEM
+#if SZ_USE_WESTMERE
 /** @copydoc sz_find_byte */
-SZ_PUBLIC sz_cptr_t sz_find_byte_nehalem(sz_cptr_t haystack, sz_size_t h_length, sz_cptr_t needle);
+SZ_PUBLIC sz_cptr_t sz_find_byte_westmere(sz_cptr_t haystack, sz_size_t h_length, sz_cptr_t needle);
 /** @copydoc sz_rfind_byte */
-SZ_PUBLIC sz_cptr_t sz_rfind_byte_nehalem(sz_cptr_t haystack, sz_size_t h_length, sz_cptr_t needle);
+SZ_PUBLIC sz_cptr_t sz_rfind_byte_westmere(sz_cptr_t haystack, sz_size_t h_length, sz_cptr_t needle);
 #endif
 
 #if SZ_USE_HASWELL
@@ -117,11 +117,11 @@ SZ_PUBLIC sz_cptr_t sz_find_serial(sz_cptr_t haystack, sz_size_t h_length, sz_cp
 /** @copydoc sz_rfind */
 SZ_PUBLIC sz_cptr_t sz_rfind_serial(sz_cptr_t haystack, sz_size_t h_length, sz_cptr_t needle, sz_size_t n_length);
 
-#if SZ_USE_NEHALEM
+#if SZ_USE_WESTMERE
 /** @copydoc sz_find */
-SZ_PUBLIC sz_cptr_t sz_find_nehalem(sz_cptr_t haystack, sz_size_t h_length, sz_cptr_t needle, sz_size_t n_length);
+SZ_PUBLIC sz_cptr_t sz_find_westmere(sz_cptr_t haystack, sz_size_t h_length, sz_cptr_t needle, sz_size_t n_length);
 /** @copydoc sz_rfind */
-SZ_PUBLIC sz_cptr_t sz_rfind_nehalem(sz_cptr_t haystack, sz_size_t h_length, sz_cptr_t needle, sz_size_t n_length);
+SZ_PUBLIC sz_cptr_t sz_rfind_westmere(sz_cptr_t haystack, sz_size_t h_length, sz_cptr_t needle, sz_size_t n_length);
 #endif
 
 #if SZ_USE_HASWELL
@@ -852,11 +852,11 @@ SZ_PUBLIC sz_cptr_t sz_rfind_serial(sz_cptr_t h, sz_size_t h_length, sz_cptr_t n
 
 #pragma endregion // Serial Implementation
 
-/*  SSE implementation of the string search algorithms for Nehalem processors and newer.
+/*  SSE implementation of the string search algorithms for Westmere processors and newer.
  *  Very minimalistic (compared to AVX-512), but still faster than the serial implementation.
  */
-#pragma region Nehalem Implementation
-#if SZ_USE_NEHALEM
+#pragma region Westmere Implementation
+#if SZ_USE_WESTMERE
 #if defined(__clang__)
 #pragma clang attribute push(__attribute__((target("sse4.2"))), apply_to = function)
 #elif defined(__GNUC__)
@@ -864,7 +864,7 @@ SZ_PUBLIC sz_cptr_t sz_rfind_serial(sz_cptr_t h, sz_size_t h_length, sz_cptr_t n
 #pragma GCC target("sse4.2")
 #endif
 
-SZ_PUBLIC sz_cptr_t sz_find_byte_nehalem(sz_cptr_t h, sz_size_t h_length, sz_cptr_t n) {
+SZ_PUBLIC sz_cptr_t sz_find_byte_westmere(sz_cptr_t h, sz_size_t h_length, sz_cptr_t n) {
     int mask;
     sz_u128_vec_t h_vec, n_vec;
     n_vec.xmm = _mm_set1_epi8(n[0]);
@@ -879,7 +879,7 @@ SZ_PUBLIC sz_cptr_t sz_find_byte_nehalem(sz_cptr_t h, sz_size_t h_length, sz_cpt
     return sz_find_byte_serial(h, h_length, n);
 }
 
-SZ_PUBLIC sz_cptr_t sz_rfind_byte_nehalem(sz_cptr_t h, sz_size_t h_length, sz_cptr_t n) {
+SZ_PUBLIC sz_cptr_t sz_rfind_byte_westmere(sz_cptr_t h, sz_size_t h_length, sz_cptr_t n) {
     int mask;
     sz_u128_vec_t h_vec, n_vec;
     n_vec.xmm = _mm_set1_epi8(n[0]);
@@ -894,11 +894,11 @@ SZ_PUBLIC sz_cptr_t sz_rfind_byte_nehalem(sz_cptr_t h, sz_size_t h_length, sz_cp
     return sz_rfind_byte_serial(h, h_length, n);
 }
 
-SZ_PUBLIC sz_cptr_t sz_find_nehalem(sz_cptr_t h, sz_size_t h_length, sz_cptr_t n, sz_size_t n_length) {
+SZ_PUBLIC sz_cptr_t sz_find_westmere(sz_cptr_t h, sz_size_t h_length, sz_cptr_t n, sz_size_t n_length) {
 
     // This almost never fires, but it's better to be safe than sorry.
     if (h_length < n_length || !n_length) return SZ_NULL_CHAR;
-    if (n_length == 1) return sz_find_byte_nehalem(h, h_length, n);
+    if (n_length == 1) return sz_find_byte_westmere(h, h_length, n);
 
     // Pick the parts of the needle that are worth comparing.
     sz_size_t offset_first, offset_mid, offset_last;
@@ -922,7 +922,7 @@ SZ_PUBLIC sz_cptr_t sz_find_nehalem(sz_cptr_t h, sz_size_t h_length, sz_cptr_t n
             _mm_movemask_epi8(_mm_cmpeq_epi8(h_last_vec.xmm, n_last_vec.xmm));
         while (matches) {
             int potential_offset = sz_u32_ctz(matches);
-            if (sz_equal_nehalem(h + potential_offset, n, n_length)) return h + potential_offset;
+            if (sz_equal_westmere(h + potential_offset, n, n_length)) return h + potential_offset;
             matches &= matches - 1;
         }
     }
@@ -930,10 +930,10 @@ SZ_PUBLIC sz_cptr_t sz_find_nehalem(sz_cptr_t h, sz_size_t h_length, sz_cptr_t n
     return sz_find_serial(h, h_length, n, n_length);
 }
 
-SZ_PUBLIC sz_cptr_t sz_rfind_nehalem(sz_cptr_t h, sz_size_t h_length, sz_cptr_t n, sz_size_t n_length) {
+SZ_PUBLIC sz_cptr_t sz_rfind_westmere(sz_cptr_t h, sz_size_t h_length, sz_cptr_t n, sz_size_t n_length) {
     // This almost never fires, but it's better to be safe than sorry.
     // if (h_length < n_length || !n_length) return SZ_NULL_CHAR;
-    // if (n_length == 1) return sz_rfind_byte_nehalem(h, h_length, n);
+    // if (n_length == 1) return sz_rfind_byte_westmere(h, h_length, n);
     //
     // Pick the parts of the needle that are worth comparing.
     sz_size_t offset_first, offset_mid, offset_last;
@@ -959,7 +959,7 @@ SZ_PUBLIC sz_cptr_t sz_rfind_nehalem(sz_cptr_t h, sz_size_t h_length, sz_cptr_t 
             _mm_movemask_epi8(_mm_cmpeq_epi8(h_last_vec.xmm, n_last_vec.xmm));
         while (matches) {
             int potential_offset = sz_u32_clz(matches) - 16;
-            if (sz_equal_nehalem(h + h_length - n_length - potential_offset, n, n_length))
+            if (sz_equal_westmere(h + h_length - n_length - potential_offset, n, n_length))
                 return h + h_length - n_length - potential_offset;
             matches &= ~(1 << (15 - potential_offset));
         }
@@ -973,8 +973,8 @@ SZ_PUBLIC sz_cptr_t sz_rfind_nehalem(sz_cptr_t h, sz_size_t h_length, sz_cptr_t 
 #elif defined(__GNUC__)
 #pragma GCC pop_options
 #endif
-#endif            // SZ_USE_NEHALEM
-#pragma endregion // Nehalem Implementation
+#endif            // SZ_USE_WESTMERE
+#pragma endregion // Westmere Implementation
 
 /*  AVX2 implementation of the string search algorithms for Haswell processors and newer.
  *  Very minimalistic (compared to AVX-512), but still faster than the serial implementation.
@@ -1964,8 +1964,8 @@ SZ_DYNAMIC sz_cptr_t sz_find_byte(sz_cptr_t haystack, sz_size_t h_length, sz_cpt
     return sz_find_byte_skylake(haystack, h_length, needle);
 #elif SZ_USE_HASWELL
     return sz_find_byte_haswell(haystack, h_length, needle);
-#elif SZ_USE_NEHALEM
-    return sz_find_byte_nehalem(haystack, h_length, needle);
+#elif SZ_USE_WESTMERE
+    return sz_find_byte_westmere(haystack, h_length, needle);
 #elif SZ_USE_SVE
     return sz_find_byte_sve(haystack, h_length, needle);
 #elif SZ_USE_NEON
@@ -1980,8 +1980,8 @@ SZ_DYNAMIC sz_cptr_t sz_rfind_byte(sz_cptr_t haystack, sz_size_t h_length, sz_cp
     return sz_rfind_byte_skylake(haystack, h_length, needle);
 #elif SZ_USE_HASWELL
     return sz_rfind_byte_haswell(haystack, h_length, needle);
-#elif SZ_USE_NEHALEM
-    return sz_rfind_byte_nehalem(haystack, h_length, needle);
+#elif SZ_USE_WESTMERE
+    return sz_rfind_byte_westmere(haystack, h_length, needle);
 #elif SZ_USE_SVE
     return sz_rfind_byte_sve(haystack, h_length, needle);
 #elif SZ_USE_NEON
@@ -1996,8 +1996,8 @@ SZ_DYNAMIC sz_cptr_t sz_find(sz_cptr_t haystack, sz_size_t h_length, sz_cptr_t n
     return sz_find_skylake(haystack, h_length, needle, n_length);
 #elif SZ_USE_HASWELL
     return sz_find_haswell(haystack, h_length, needle, n_length);
-#elif SZ_USE_NEHALEM
-    return sz_find_nehalem(haystack, h_length, needle, n_length);
+#elif SZ_USE_WESTMERE
+    return sz_find_westmere(haystack, h_length, needle, n_length);
 #elif SZ_USE_SVE
     return sz_find_sve(haystack, h_length, needle, n_length);
 #elif SZ_USE_NEON
@@ -2012,8 +2012,8 @@ SZ_DYNAMIC sz_cptr_t sz_rfind(sz_cptr_t haystack, sz_size_t h_length, sz_cptr_t 
     return sz_rfind_skylake(haystack, h_length, needle, n_length);
 #elif SZ_USE_HASWELL
     return sz_rfind_haswell(haystack, h_length, needle, n_length);
-#elif SZ_USE_NEHALEM
-    return sz_rfind_nehalem(haystack, h_length, needle, n_length);
+#elif SZ_USE_WESTMERE
+    return sz_rfind_westmere(haystack, h_length, needle, n_length);
 #elif SZ_USE_NEON
     return sz_rfind_neon(haystack, h_length, needle, n_length);
 #else

--- a/include/stringzilla/find.h
+++ b/include/stringzilla/find.h
@@ -60,6 +60,13 @@ SZ_PUBLIC sz_cptr_t sz_find_byte_serial(sz_cptr_t haystack, sz_size_t h_length, 
 /** @copydoc sz_rfind_byte */
 SZ_PUBLIC sz_cptr_t sz_rfind_byte_serial(sz_cptr_t haystack, sz_size_t h_length, sz_cptr_t needle);
 
+#if SZ_USE_NEHALEM
+/** @copydoc sz_find_byte */
+SZ_PUBLIC sz_cptr_t sz_find_byte_nehalem(sz_cptr_t haystack, sz_size_t h_length, sz_cptr_t needle);
+/** @copydoc sz_rfind_byte */
+SZ_PUBLIC sz_cptr_t sz_rfind_byte_nehalem(sz_cptr_t haystack, sz_size_t h_length, sz_cptr_t needle);
+#endif
+
 #if SZ_USE_HASWELL
 /** @copydoc sz_find_byte */
 SZ_PUBLIC sz_cptr_t sz_find_byte_haswell(sz_cptr_t haystack, sz_size_t h_length, sz_cptr_t needle);
@@ -109,6 +116,13 @@ SZ_DYNAMIC sz_cptr_t sz_rfind(sz_cptr_t haystack, sz_size_t h_length, sz_cptr_t 
 SZ_PUBLIC sz_cptr_t sz_find_serial(sz_cptr_t haystack, sz_size_t h_length, sz_cptr_t needle, sz_size_t n_length);
 /** @copydoc sz_rfind */
 SZ_PUBLIC sz_cptr_t sz_rfind_serial(sz_cptr_t haystack, sz_size_t h_length, sz_cptr_t needle, sz_size_t n_length);
+
+#if SZ_USE_NEHALEM
+/** @copydoc sz_find */
+SZ_PUBLIC sz_cptr_t sz_find_nehalem(sz_cptr_t haystack, sz_size_t h_length, sz_cptr_t needle, sz_size_t n_length);
+/** @copydoc sz_rfind */
+SZ_PUBLIC sz_cptr_t sz_rfind_nehalem(sz_cptr_t haystack, sz_size_t h_length, sz_cptr_t needle, sz_size_t n_length);
+#endif
 
 #if SZ_USE_HASWELL
 /** @copydoc sz_find */
@@ -837,6 +851,130 @@ SZ_PUBLIC sz_cptr_t sz_rfind_serial(sz_cptr_t h, sz_size_t h_length, sz_cptr_t n
 }
 
 #pragma endregion // Serial Implementation
+
+/*  SSE implementation of the string search algorithms for Nehalem processors and newer.
+ *  Very minimalistic (compared to AVX-512), but still faster than the serial implementation.
+ */
+#pragma region Nehalem Implementation
+#if SZ_USE_NEHALEM
+#if defined(__clang__)
+#pragma clang attribute push(__attribute__((target("sse4.2"))), apply_to = function)
+#elif defined(__GNUC__)
+#pragma GCC push_options
+#pragma GCC target("sse4.2")
+#endif
+
+SZ_PUBLIC sz_cptr_t sz_find_byte_nehalem(sz_cptr_t h, sz_size_t h_length, sz_cptr_t n) {
+    int mask;
+    sz_u128_vec_t h_vec, n_vec;
+    n_vec.xmm = _mm_set1_epi8(n[0]);
+
+    while (h_length >= 16) {
+        h_vec.xmm = _mm_lddqu_si128((__m128i const *)h);
+        mask = _mm_movemask_epi8(_mm_cmpeq_epi8(h_vec.xmm, n_vec.xmm));
+        if (mask) return h + sz_u32_ctz(mask);
+        h += 16, h_length -= 16;
+    }
+
+    return sz_find_byte_serial(h, h_length, n);
+}
+
+SZ_PUBLIC sz_cptr_t sz_rfind_byte_nehalem(sz_cptr_t h, sz_size_t h_length, sz_cptr_t n) {
+    int mask;
+    sz_u128_vec_t h_vec, n_vec;
+    n_vec.xmm = _mm_set1_epi8(n[0]);
+
+    while (h_length >= 16) {
+        h_vec.xmm = _mm_lddqu_si128((__m128i const *)(h + h_length - 16));
+        mask = _mm_movemask_epi8(_mm_cmpeq_epi8(h_vec.xmm, n_vec.xmm));
+        if (mask) return h + h_length - 1 - (sz_u32_clz(mask) - 16);
+        h_length -= 16;
+    }
+
+    return sz_rfind_byte_serial(h, h_length, n);
+}
+
+SZ_PUBLIC sz_cptr_t sz_find_nehalem(sz_cptr_t h, sz_size_t h_length, sz_cptr_t n, sz_size_t n_length) {
+
+    // This almost never fires, but it's better to be safe than sorry.
+    if (h_length < n_length || !n_length) return SZ_NULL_CHAR;
+    if (n_length == 1) return sz_find_byte_nehalem(h, h_length, n);
+
+    // Pick the parts of the needle that are worth comparing.
+    sz_size_t offset_first, offset_mid, offset_last;
+    sz_locate_needle_anomalies_(n, n_length, &offset_first, &offset_mid, &offset_last);
+
+    // Broadcast those characters into XMM registers.
+    int matches;
+    sz_u128_vec_t h_first_vec, h_mid_vec, h_last_vec, n_first_vec, n_mid_vec, n_last_vec;
+    n_first_vec.xmm = _mm_set1_epi8(n[offset_first]);
+    n_mid_vec.xmm = _mm_set1_epi8(n[offset_mid]);
+    n_last_vec.xmm = _mm_set1_epi8(n[offset_last]);
+
+    // Scan through the string.
+    for (; h_length >= n_length + 16; h += 16, h_length -= 16) {
+        h_first_vec.xmm = _mm_lddqu_si128((__m128i const *)(h + offset_first));
+        h_mid_vec.xmm = _mm_lddqu_si128((__m128i const *)(h + offset_mid));
+        h_last_vec.xmm = _mm_lddqu_si128((__m128i const *)(h + offset_last));
+        matches = //
+            _mm_movemask_epi8(_mm_cmpeq_epi8(h_first_vec.xmm, n_first_vec.xmm)) &
+            _mm_movemask_epi8(_mm_cmpeq_epi8(h_mid_vec.xmm, n_mid_vec.xmm)) &
+            _mm_movemask_epi8(_mm_cmpeq_epi8(h_last_vec.xmm, n_last_vec.xmm));
+        while (matches) {
+            int potential_offset = sz_u32_ctz(matches);
+            if (sz_equal_nehalem(h + potential_offset, n, n_length)) return h + potential_offset;
+            matches &= matches - 1;
+        }
+    }
+
+    return sz_find_serial(h, h_length, n, n_length);
+}
+
+SZ_PUBLIC sz_cptr_t sz_rfind_nehalem(sz_cptr_t h, sz_size_t h_length, sz_cptr_t n, sz_size_t n_length) {
+    // This almost never fires, but it's better to be safe than sorry.
+    // if (h_length < n_length || !n_length) return SZ_NULL_CHAR;
+    // if (n_length == 1) return sz_rfind_byte_nehalem(h, h_length, n);
+    //
+    // Pick the parts of the needle that are worth comparing.
+    sz_size_t offset_first, offset_mid, offset_last;
+    sz_locate_needle_anomalies_(n, n_length, &offset_first, &offset_mid, &offset_last);
+
+    // Broadcast those characters into XMM registers.
+    int matches;
+    sz_u128_vec_t h_first_vec, h_mid_vec, h_last_vec, n_first_vec, n_mid_vec, n_last_vec;
+    n_first_vec.xmm = _mm_set1_epi8(n[offset_first]);
+    n_mid_vec.xmm = _mm_set1_epi8(n[offset_mid]);
+    n_last_vec.xmm = _mm_set1_epi8(n[offset_last]);
+
+    // Scan through the string.
+    sz_cptr_t h_reversed;
+    for (; h_length >= n_length + 16; h_length -= 16) {
+        h_reversed = h + h_length - n_length - 16 + 1;
+        h_first_vec.xmm = _mm_lddqu_si128((__m128i const *)(h_reversed + offset_first));
+        h_mid_vec.xmm = _mm_lddqu_si128((__m128i const *)(h_reversed + offset_mid));
+        h_last_vec.xmm = _mm_lddqu_si128((__m128i const *)(h_reversed + offset_last));
+        matches = //
+            _mm_movemask_epi8(_mm_cmpeq_epi8(h_first_vec.xmm, n_first_vec.xmm)) &
+            _mm_movemask_epi8(_mm_cmpeq_epi8(h_mid_vec.xmm, n_mid_vec.xmm)) &
+            _mm_movemask_epi8(_mm_cmpeq_epi8(h_last_vec.xmm, n_last_vec.xmm));
+        while (matches) {
+            int potential_offset = sz_u32_clz(matches) - 16;
+            if (sz_equal_nehalem(h + h_length - n_length - potential_offset, n, n_length))
+                return h + h_length - n_length - potential_offset;
+            matches &= ~(1 << (15 - potential_offset));
+        }
+    }
+
+    return sz_rfind_serial(h, h_length, n, n_length);
+}
+
+#if defined(__clang__)
+#pragma clang attribute pop
+#elif defined(__GNUC__)
+#pragma GCC pop_options
+#endif
+#endif            // SZ_USE_NEHALEM
+#pragma endregion // Nehalem Implementation
 
 /*  AVX2 implementation of the string search algorithms for Haswell processors and newer.
  *  Very minimalistic (compared to AVX-512), but still faster than the serial implementation.
@@ -1826,6 +1964,8 @@ SZ_DYNAMIC sz_cptr_t sz_find_byte(sz_cptr_t haystack, sz_size_t h_length, sz_cpt
     return sz_find_byte_skylake(haystack, h_length, needle);
 #elif SZ_USE_HASWELL
     return sz_find_byte_haswell(haystack, h_length, needle);
+#elif SZ_USE_NEHALEM
+    return sz_find_byte_nehalem(haystack, h_length, needle);
 #elif SZ_USE_SVE
     return sz_find_byte_sve(haystack, h_length, needle);
 #elif SZ_USE_NEON
@@ -1840,6 +1980,8 @@ SZ_DYNAMIC sz_cptr_t sz_rfind_byte(sz_cptr_t haystack, sz_size_t h_length, sz_cp
     return sz_rfind_byte_skylake(haystack, h_length, needle);
 #elif SZ_USE_HASWELL
     return sz_rfind_byte_haswell(haystack, h_length, needle);
+#elif SZ_USE_NEHALEM
+    return sz_rfind_byte_nehalem(haystack, h_length, needle);
 #elif SZ_USE_SVE
     return sz_rfind_byte_sve(haystack, h_length, needle);
 #elif SZ_USE_NEON
@@ -1854,6 +1996,8 @@ SZ_DYNAMIC sz_cptr_t sz_find(sz_cptr_t haystack, sz_size_t h_length, sz_cptr_t n
     return sz_find_skylake(haystack, h_length, needle, n_length);
 #elif SZ_USE_HASWELL
     return sz_find_haswell(haystack, h_length, needle, n_length);
+#elif SZ_USE_NEHALEM
+    return sz_find_nehalem(haystack, h_length, needle, n_length);
 #elif SZ_USE_SVE
     return sz_find_sve(haystack, h_length, needle, n_length);
 #elif SZ_USE_NEON
@@ -1868,6 +2012,8 @@ SZ_DYNAMIC sz_cptr_t sz_rfind(sz_cptr_t haystack, sz_size_t h_length, sz_cptr_t 
     return sz_rfind_skylake(haystack, h_length, needle, n_length);
 #elif SZ_USE_HASWELL
     return sz_rfind_haswell(haystack, h_length, needle, n_length);
+#elif SZ_USE_NEHALEM
+    return sz_rfind_nehalem(haystack, h_length, needle, n_length);
 #elif SZ_USE_NEON
     return sz_rfind_neon(haystack, h_length, needle, n_length);
 #else

--- a/include/stringzilla/stringzilla.h
+++ b/include/stringzilla/stringzilla.h
@@ -51,7 +51,7 @@
  *
  *  Different generations of CPUs and SIMD capabilities can be enabled or disabled with the following macros:
  *
- *  - `SZ_USE_WESTMERE=?` - whether to use SSE4.2 instructions on x86_64.
+ *  - `SZ_USE_WESTMERE=?` - whether to use SSE4.2 & AES-NI instructions on x86_64.
  *  - `SZ_USE_HASWELL=?` - whether to use AVX2 instructions on x86_64.
  *  - `SZ_USE_SKYLAKE=?` - whether to use AVX-512 instructions on x86_64.
  *  - `SZ_USE_ICE=?` - whether to use AVX-512 VBMI & wider AES instructions on x86_64.

--- a/include/stringzilla/stringzilla.h
+++ b/include/stringzilla/stringzilla.h
@@ -51,7 +51,7 @@
  *
  *  Different generations of CPUs and SIMD capabilities can be enabled or disabled with the following macros:
  *
- *  - `SZ_USE_NEHALEM=?` - whether to use SSE4.2 instructions on x86_64.
+ *  - `SZ_USE_WESTMERE=?` - whether to use SSE4.2 instructions on x86_64.
  *  - `SZ_USE_HASWELL=?` - whether to use AVX2 instructions on x86_64.
  *  - `SZ_USE_SKYLAKE=?` - whether to use AVX-512 instructions on x86_64.
  *  - `SZ_USE_ICE=?` - whether to use AVX-512 VBMI & wider AES instructions on x86_64.
@@ -115,7 +115,7 @@ SZ_INTERNAL sz_size_t sz_capabilities_to_strings_implementation_(sz_capability_t
         {sz_cap_serial_k, "serial"},
         {sz_cap_parallel_k, "parallel"},
         //
-        {sz_cap_nehalem_k, "nehalem"},
+        {sz_cap_westmere_k, "westmere"},
         {sz_cap_haswell_k, "haswell"},
         {sz_cap_skylake_k, "skylake"},
         {sz_cap_ice_k, "ice"},
@@ -158,7 +158,7 @@ SZ_INTERNAL sz_capability_t sz_capability_from_string_implementation_(char const
     if (sz_equal_null_terminated_serial(name, "serial") == sz_true_k) return sz_cap_serial_k;
     if (sz_equal_null_terminated_serial(name, "parallel") == sz_true_k) return sz_cap_parallel_k;
     // x86
-    if (sz_equal_null_terminated_serial(name, "nehalem") == sz_true_k) return sz_cap_nehalem_k;
+    if (sz_equal_null_terminated_serial(name, "westmere") == sz_true_k) return sz_cap_westmere_k;
     if (sz_equal_null_terminated_serial(name, "haswell") == sz_true_k) return sz_cap_haswell_k;
     if (sz_equal_null_terminated_serial(name, "skylake") == sz_true_k) return sz_cap_skylake_k;
     if (sz_equal_null_terminated_serial(name, "ice") == sz_true_k) return sz_cap_ice_k;
@@ -318,7 +318,7 @@ SZ_PUBLIC sz_capability_t sz_capabilities_implementation_arm_(void) {
 
 SZ_PUBLIC sz_capability_t sz_capabilities_implementation_x86_(void) {
 
-#if SZ_USE_NEHALEM || SZ_USE_HASWELL || SZ_USE_SKYLAKE || SZ_USE_ICE
+#if SZ_USE_WESTMERE || SZ_USE_HASWELL || SZ_USE_SKYLAKE || SZ_USE_ICE
 
     /// The states of 4 registers populated for a specific "cpuid" assembly call
     union four_registers_t {
@@ -370,11 +370,12 @@ SZ_PUBLIC sz_capability_t sz_capabilities_implementation_x86_(void) {
     unsigned supports_avx512vbmi2 = os_avx512_enabled && ((info7.named.ecx & 0x00000040u) != 0);
     unsigned supports_vaes = os_avx512_enabled && ((info7.named.ecx & 0x00000200u) != 0);
 
-    // Check for SSE4.2 (Function ID 1), masked by OS state
+    // Check for SSE4.2 and AES-NI (Function ID 1), masked by OS state
     unsigned supports_sse42 = ((info1.named.ecx & 0x00100000u) != 0);
+    unsigned supports_aesni = ((info1.named.ecx & 0x02000000) != 0);
 
     return (sz_capability_t)(                                                               //
-        (sz_cap_nehalem_k * supports_sse42) |                                               //
+        (sz_cap_westmere_k * (supports_sse42 && supports_aesni)) |                          //
         (sz_cap_haswell_k * supports_avx2) |                                                //
         (sz_cap_skylake_k * (supports_avx512f && supports_avx512vl && supports_avx512bw)) | //
         (sz_cap_ice_k * (supports_avx512vbmi && supports_avx512vbmi2 && supports_vaes)) |   //

--- a/include/stringzilla/stringzilla.h
+++ b/include/stringzilla/stringzilla.h
@@ -373,11 +373,11 @@ SZ_PUBLIC sz_capability_t sz_capabilities_implementation_x86_(void) {
     // Check for SSE4.2 (Function ID 1), masked by OS state
     unsigned supports_sse42 = ((info1.named.ecx & 0x00100000u) != 0);
 
-    return (sz_capability_t)(                                                                                //
-        (sz_cap_nehalem_k * supports_sse42) |                                                                //
-        (sz_cap_haswell_k * supports_avx2) |                                                                 //
-        (sz_cap_skylake_k * (supports_avx512f && supports_avx512vl && supports_avx512bw && supports_vaes)) | //
-        (sz_cap_ice_k * (supports_avx512vbmi && supports_avx512vbmi2)) |                                     //
+    return (sz_capability_t)(                                                               //
+        (sz_cap_nehalem_k * supports_sse42) |                                               //
+        (sz_cap_haswell_k * supports_avx2) |                                                //
+        (sz_cap_skylake_k * (supports_avx512f && supports_avx512vl && supports_avx512bw)) | //
+        (sz_cap_ice_k * (supports_avx512vbmi && supports_avx512vbmi2 && supports_vaes)) |   //
         (sz_cap_serial_k));
 #else
     return sz_cap_serial_k;

--- a/include/stringzilla/types.h
+++ b/include/stringzilla/types.h
@@ -218,7 +218,7 @@
  *  All of those can be controlled by the user.
  */
 #if !defined(SZ_USE_WESTMERE)
-#if SZ_IS_64BIT_X86_ && defined(__SSE4_2__)
+#if SZ_IS_64BIT_X86_ && defined(__SSE4_2__) && defined(__AES__)
 #define SZ_USE_WESTMERE (1)
 #else
 #define SZ_USE_WESTMERE (0)
@@ -242,7 +242,7 @@
 #endif
 
 #if !defined(SZ_USE_ICE)
-#if SZ_IS_64BIT_X86_ && defined(__AVX512BW__)
+#if SZ_IS_64BIT_X86_ && defined(__AVX512BW__) && defined(__VAES__)
 #define SZ_USE_ICE (1)
 #else
 #define SZ_USE_ICE (0)
@@ -825,7 +825,7 @@ typedef union sz_u64_vec_t {
  *          as well as 1x XMM register.
  */
 typedef union sz_u128_vec_t {
-#if SZ_USE_HASWELL || SZ_USE_WESTMERE
+#if SZ_USE_WESTMERE || SZ_USE_HASWELL
     __m128i xmm;
     __m128d xmm_pd;
     __m128 xmm_ps;
@@ -859,7 +859,7 @@ typedef union sz_u256_vec_t {
     __m256d ymm_pd;
     __m256 ymm_ps;
 #endif
-#if SZ_USE_HASWELL || SZ_USE_WESTMERE
+#if SZ_USE_WESTMERE || SZ_USE_HASWELL
     __m128i xmms[2];
 #endif
 #if SZ_USE_NEON
@@ -894,7 +894,7 @@ typedef union sz_u512_vec_t {
 #if SZ_USE_HASWELL || SZ_USE_SKYLAKE || SZ_USE_ICE
     __m256i ymms[2];
 #endif
-#if SZ_USE_HASWELL || SZ_USE_SKYLAKE || SZ_USE_ICE || SZ_USE_WESTMERE
+#if SZ_USE_WESTMERE || SZ_USE_HASWELL || SZ_USE_SKYLAKE || SZ_USE_ICE
     __m128i xmms[4];
 #endif
 #if SZ_USE_NEON

--- a/include/stringzilla/types.h
+++ b/include/stringzilla/types.h
@@ -220,6 +220,8 @@
 #if !defined(SZ_USE_WESTMERE)
 #if SZ_IS_64BIT_X86_ && defined(__SSE4_2__) && defined(__AES__)
 #define SZ_USE_WESTMERE (1)
+#elif SZ_IS_64BIT_X86_ && defined(_MSC_VER) && defined(__AVX__)
+#define SZ_USE_WESTMERE (1) // ! MSVC doesn't expose `__SSE4_2__`, `__AES__` macros
 #else
 #define SZ_USE_WESTMERE (0)
 #endif
@@ -244,19 +246,25 @@
 #if !defined(SZ_USE_ICE)
 #if SZ_IS_64BIT_X86_ && defined(__AVX512BW__) && defined(__VAES__)
 #define SZ_USE_ICE (1)
+#elif SZ_IS_64BIT_X86_ && defined(_MSC_VER) && defined(__AVX512BW__)
+#define SZ_USE_ICE (1) // ! MSVC doesn't expose `__VAES__` macros
 #else
 #define SZ_USE_ICE (0)
 #endif
 #endif
 
+/*  NEON support is optional in Armv7/AArch32, but mandatory from 8.0 onwards. */
 #if !defined(SZ_USE_NEON)
 #if SZ_IS_64BIT_ARM_ && defined(__ARM_NEON)
 #define SZ_USE_NEON (1)
+#elif SZ_IS_64BIT_X86_ && defined(_MSC_VER) && defined(__ARM_ARCH) && __ARM_ARCH >= 800
+#define SZ_USE_NEON (1) // ! MSVC doesn't expose `__ARM_NEON` macros
 #else
 #define SZ_USE_NEON (0)
 #endif
 #endif
 
+/*  SVE is optional since Armv8.2-A, but never became mandatory and MSVC has no way to probe for it. */
 #if !defined(SZ_USE_SVE)
 #if SZ_IS_64BIT_ARM_ && defined(__ARM_FEATURE_SVE)
 #define SZ_USE_SVE (1)
@@ -265,6 +273,7 @@
 #endif
 #endif
 
+/*  SVE2 is optional since Armv9.0-A, but never became mandatory and MSVC has no way to probe for it. */
 #if !defined(SZ_USE_SVE2)
 #if SZ_IS_64BIT_ARM_ && defined(__ARM_FEATURE_SVE2)
 #define SZ_USE_SVE2 (1)
@@ -273,6 +282,7 @@
 #endif
 #endif
 
+/*  AES is optional since Armv8.0-A, but never became mandatory and MSVC has no way to probe for it. */
 #if !defined(SZ_USE_NEON_AES)
 #if SZ_IS_64BIT_ARM_ && defined(__ARM_FEATURE_AES)
 #define SZ_USE_NEON_AES (1)
@@ -281,6 +291,7 @@
 #endif
 #endif
 
+/*  SVE2 AES is optional since Armv9.0-A, but never became mandatory and MSVC has no way to probe for it. */
 #if !defined(SZ_USE_SVE2_AES)
 #if SZ_IS_64BIT_ARM_ && defined(__ARM_FEATURE_SVE2_AES)
 #define SZ_USE_SVE2_AES (1)

--- a/include/stringzilla/types.h
+++ b/include/stringzilla/types.h
@@ -217,11 +217,11 @@
 /*  Compile-time hardware features detection.
  *  All of those can be controlled by the user.
  */
-#if !defined(SZ_USE_NEHALEM)
+#if !defined(SZ_USE_WESTMERE)
 #if SZ_IS_64BIT_X86_ && defined(__SSE4_2__)
-#define SZ_USE_NEHALEM (1)
+#define SZ_USE_WESTMERE (1)
 #else
-#define SZ_USE_NEHALEM (0)
+#define SZ_USE_WESTMERE (0)
 #endif
 #endif
 
@@ -323,9 +323,9 @@
 
 /*  Hardware-specific headers for different SIMD intrinsics and register wrappers.
  */
-#if SZ_USE_NEHALEM || SZ_USE_HASWELL || SZ_USE_SKYLAKE || SZ_USE_ICE
+#if SZ_USE_WESTMERE || SZ_USE_HASWELL || SZ_USE_SKYLAKE || SZ_USE_ICE
 #include <immintrin.h>
-#endif // SZ_USE_NEHALEM || SZ_USE_HASWELL || SZ_USE_SKYLAKE || SZ_USE_ICE
+#endif // SZ_USE_WESTMERE || SZ_USE_HASWELL || SZ_USE_SKYLAKE || SZ_USE_ICE
 #if SZ_USE_NEON
 #if !defined(_MSC_VER)
 #include <arm_acle.h>
@@ -534,10 +534,10 @@ typedef enum sz_capability_t {
     sz_cap_parallel_k = 1 << 2, ///< Multi-threading via Fork Union or other OpenMP-like engines
     sz_cap_any_k = 0x7FFFFFFF,  ///< Mask representing any capability with `INT_MAX`
 
-    sz_cap_haswell_k = 1 << 5, ///< x86 AVX2 capability with FMA and F16C extensions
-    sz_cap_skylake_k = 1 << 6, ///< x86 AVX512 baseline capability
-    sz_cap_ice_k = 1 << 7,     ///< x86 AVX512 capability with advanced integer algos and AES extensions
-    sz_cap_nehalem_k = 1 << 8, ///< x86 SSE4.2 capability
+    sz_cap_haswell_k = 1 << 5,  ///< x86 AVX2 capability with FMA and F16C extensions
+    sz_cap_skylake_k = 1 << 6,  ///< x86 AVX512 baseline capability
+    sz_cap_ice_k = 1 << 7,      ///< x86 AVX512 capability with advanced integer algos and AES extensions
+    sz_cap_westmere_k = 1 << 8, ///< x86 SSE4.2 + AES-NI capability
 
     sz_cap_neon_k = 1 << 10,     ///< ARM NEON baseline capability
     sz_cap_neon_aes_k = 1 << 11, ///< ARM NEON baseline capability with AES extensions
@@ -559,7 +559,7 @@ typedef enum sz_capability_t {
 
     // Aggregates for different StringZillas builds
     sz_caps_cpus_k = sz_cap_serial_k | sz_cap_parallel_k | sz_cap_haswell_k | sz_cap_skylake_k | sz_cap_ice_k |
-                     sz_cap_nehalem_k | sz_cap_neon_k | sz_cap_neon_aes_k | sz_cap_sve_k | sz_cap_sve2_k |
+                     sz_cap_westmere_k | sz_cap_neon_k | sz_cap_neon_aes_k | sz_cap_sve_k | sz_cap_sve2_k |
                      sz_cap_sve2_aes_k,
     sz_caps_cuda_k = sz_cap_cuda_k | sz_cap_kepler_k | sz_cap_hopper_k,
 
@@ -825,7 +825,7 @@ typedef union sz_u64_vec_t {
  *          as well as 1x XMM register.
  */
 typedef union sz_u128_vec_t {
-#if SZ_USE_HASWELL || SZ_USE_NEHALEM
+#if SZ_USE_HASWELL || SZ_USE_WESTMERE
     __m128i xmm;
     __m128d xmm_pd;
     __m128 xmm_ps;
@@ -859,7 +859,7 @@ typedef union sz_u256_vec_t {
     __m256d ymm_pd;
     __m256 ymm_ps;
 #endif
-#if SZ_USE_HASWELL || SZ_USE_NEHALEM
+#if SZ_USE_HASWELL || SZ_USE_WESTMERE
     __m128i xmms[2];
 #endif
 #if SZ_USE_NEON
@@ -894,7 +894,7 @@ typedef union sz_u512_vec_t {
 #if SZ_USE_HASWELL || SZ_USE_SKYLAKE || SZ_USE_ICE
     __m256i ymms[2];
 #endif
-#if SZ_USE_HASWELL || SZ_USE_SKYLAKE || SZ_USE_ICE || SZ_USE_NEHALEM
+#if SZ_USE_HASWELL || SZ_USE_SKYLAKE || SZ_USE_ICE || SZ_USE_WESTMERE
     __m128i xmms[4];
 #endif
 #if SZ_USE_NEON

--- a/scripts/bench.hpp
+++ b/scripts/bench.hpp
@@ -455,6 +455,7 @@ inline environment_t build_environment(                                        /
     std::printf(" - Mean token length: %.2f bytes\n", mean_token_length);
 
     std::printf("Compile-time capabilities:\n");
+    std::printf("- Uses Nehalem: %s \n", SZ_USE_NEHALEM ? "yes" : "no");
     std::printf("- Uses Haswell: %s \n", SZ_USE_HASWELL ? "yes" : "no");
     std::printf("- Uses Skylake: %s \n", SZ_USE_SKYLAKE ? "yes" : "no");
     std::printf("- Uses Ice Lake: %s \n", SZ_USE_ICE ? "yes" : "no");

--- a/scripts/bench.hpp
+++ b/scripts/bench.hpp
@@ -455,7 +455,7 @@ inline environment_t build_environment(                                        /
     std::printf(" - Mean token length: %.2f bytes\n", mean_token_length);
 
     std::printf("Compile-time capabilities:\n");
-    std::printf("- Uses Nehalem: %s \n", SZ_USE_NEHALEM ? "yes" : "no");
+    std::printf("- Uses Westmere: %s \n", SZ_USE_WESTMERE ? "yes" : "no");
     std::printf("- Uses Haswell: %s \n", SZ_USE_HASWELL ? "yes" : "no");
     std::printf("- Uses Skylake: %s \n", SZ_USE_SKYLAKE ? "yes" : "no");
     std::printf("- Uses Ice Lake: %s \n", SZ_USE_ICE ? "yes" : "no");

--- a/scripts/bench_container.cpp
+++ b/scripts/bench_container.cpp
@@ -142,8 +142,8 @@ void bench_associative_lookups_with_different_simd_backends(environment_t const 
         bench_unary(env, "map<sz_order_haswell>::find", callable_no_op_t(), callable_map, callable_map.preprocessor())
             .log(base_map);
         auto callable_umap = callable_for_associative_lookups<std::unordered_map<
-            std::string_view, unsigned, hash_from_sz<sz_hash_haswell>, equal_to_from_sz<sz_equal_haswell>>>(env);
-        bench_unary(env, "unordered_map<sz_hash_haswell, sz_equal_haswell>::find", callable_no_op_t(), callable_umap,
+            std::string_view, unsigned, hash_from_sz<sz_hash_westmere>, equal_to_from_sz<sz_equal_haswell>>>(env);
+        bench_unary(env, "unordered_map<sz_hash_westmere, sz_equal_haswell>::find", callable_no_op_t(), callable_umap,
                     callable_umap.preprocessor())
             .log(base_umap);
     }

--- a/scripts/bench_find.cpp
+++ b/scripts/bench_find.cpp
@@ -215,6 +215,14 @@ void bench_substring_search(environment_t const &env) {
                 callable_for_substring_search<sz::range_rmatches, matcher_from_sz_find<sz_rfind_haswell>>(env))
         .log(base_reverse);
 #endif
+#if SZ_USE_NEHALEM
+    bench_unary(env, "sz_find_nehalem", base_call,
+                callable_for_substring_search<sz::range_matches, matcher_from_sz_find<sz_find_nehalem>>(env))
+        .log(base);
+    bench_unary(env, "sz_rfind_nehalem", base_call,
+                callable_for_substring_search<sz::range_rmatches, matcher_from_sz_find<sz_rfind_nehalem>>(env))
+        .log(base_reverse);
+#endif
 #if SZ_USE_SVE
     bench_unary(env, "sz_find_sve", base_call,
                 callable_for_substring_search<sz::range_matches, matcher_from_sz_find<sz_find_sve>>(env))
@@ -387,6 +395,14 @@ void bench_byte_search(environment_t const &env) {
         .log(base);
     bench_unary(env, "sz_rfind_byte_haswell", base_call,
                 callable_for_byte_search<sz::range_rmatches, matcher_from_sz_find_byte<sz_rfind_byte_haswell>>(env))
+        .log(base_reverse);
+#endif
+#if SZ_USE_NEHALEM
+    bench_unary(env, "sz_find_byte_nehalem", base_call,
+                callable_for_byte_search<sz::range_matches, matcher_from_sz_find_byte<sz_find_byte_nehalem>>(env))
+        .log(base);
+    bench_unary(env, "sz_rfind_byte_nehalem", base_call,
+                callable_for_byte_search<sz::range_rmatches, matcher_from_sz_find_byte<sz_rfind_byte_nehalem>>(env))
         .log(base_reverse);
 #endif
 #if SZ_USE_NEON

--- a/scripts/bench_find.cpp
+++ b/scripts/bench_find.cpp
@@ -215,12 +215,12 @@ void bench_substring_search(environment_t const &env) {
                 callable_for_substring_search<sz::range_rmatches, matcher_from_sz_find<sz_rfind_haswell>>(env))
         .log(base_reverse);
 #endif
-#if SZ_USE_NEHALEM
-    bench_unary(env, "sz_find_nehalem", base_call,
-                callable_for_substring_search<sz::range_matches, matcher_from_sz_find<sz_find_nehalem>>(env))
+#if SZ_USE_WESTMERE
+    bench_unary(env, "sz_find_westmere", base_call,
+                callable_for_substring_search<sz::range_matches, matcher_from_sz_find<sz_find_westmere>>(env))
         .log(base);
-    bench_unary(env, "sz_rfind_nehalem", base_call,
-                callable_for_substring_search<sz::range_rmatches, matcher_from_sz_find<sz_rfind_nehalem>>(env))
+    bench_unary(env, "sz_rfind_westmere", base_call,
+                callable_for_substring_search<sz::range_rmatches, matcher_from_sz_find<sz_rfind_westmere>>(env))
         .log(base_reverse);
 #endif
 #if SZ_USE_SVE
@@ -397,12 +397,12 @@ void bench_byte_search(environment_t const &env) {
                 callable_for_byte_search<sz::range_rmatches, matcher_from_sz_find_byte<sz_rfind_byte_haswell>>(env))
         .log(base_reverse);
 #endif
-#if SZ_USE_NEHALEM
-    bench_unary(env, "sz_find_byte_nehalem", base_call,
-                callable_for_byte_search<sz::range_matches, matcher_from_sz_find_byte<sz_find_byte_nehalem>>(env))
+#if SZ_USE_WESTMERE
+    bench_unary(env, "sz_find_byte_westmere", base_call,
+                callable_for_byte_search<sz::range_matches, matcher_from_sz_find_byte<sz_find_byte_westmere>>(env))
         .log(base);
-    bench_unary(env, "sz_rfind_byte_nehalem", base_call,
-                callable_for_byte_search<sz::range_rmatches, matcher_from_sz_find_byte<sz_rfind_byte_nehalem>>(env))
+    bench_unary(env, "sz_rfind_byte_westmere", base_call,
+                callable_for_byte_search<sz::range_rmatches, matcher_from_sz_find_byte<sz_rfind_byte_westmere>>(env))
         .log(base_reverse);
 #endif
 #if SZ_USE_NEON

--- a/scripts/bench_memory.cpp
+++ b/scripts/bench_memory.cpp
@@ -289,10 +289,12 @@ void bench_fill(environment_t const &env) {
     auto random_call = fill_random_from_sz<sz_fill_random_serial> {env, o};
     bench_result_t random = bench_unary(env, "sz_fill_random_serial", random_call).log(zeros);
 
+#if SZ_USE_WESTMERE
+    bench_unary(env, "sz_fill_random_westmere", random_call, fill_random_from_sz<sz_fill_random_westmere> {env, o})
+        .log(zeros, random);
+#endif
 #if SZ_USE_HASWELL
     bench_unary(env, "sz_fill_haswell", fill_from_sz<sz_fill_haswell> {env, o}).log(zeros);
-    bench_unary(env, "sz_fill_random_haswell", random_call, fill_random_from_sz<sz_fill_random_haswell> {env, o})
-        .log(zeros, random);
 #endif
 #if SZ_USE_SKYLAKE
     bench_unary(env, "sz_fill_skylake", fill_from_sz<sz_fill_skylake> {env, o}).log(zeros);

--- a/scripts/bench_token.cpp
+++ b/scripts/bench_token.cpp
@@ -169,8 +169,8 @@ void bench_hashing(environment_t const &env) {
     auto validator = hash_from_sz<sz_hash_serial> {env};
     bench_result_t base = bench_unary(env, "sz_hash_serial", validator).log();
     bench_result_t base_stl = bench_unary(env, "std::hash", hash_from_std_t {env}).log(base);
-#if SZ_USE_HASWELL
-    bench_unary(env, "sz_hash_haswell", validator, hash_from_sz<sz_hash_haswell> {env}).log(base, base_stl);
+#if SZ_USE_WESTMERE
+    bench_unary(env, "sz_hash_westmere", validator, hash_from_sz<sz_hash_westmere> {env}).log(base, base_stl);
 #endif
 #if SZ_USE_SKYLAKE
     bench_unary(env, "sz_hash_skylake", validator, hash_from_sz<sz_hash_skylake> {env}).log(base, base_stl);
@@ -193,10 +193,10 @@ void bench_stream_hashing(environment_t const &env) {
     bench_result_t base = bench_unary(env, "sz_hash_stream_serial", validator).log();
     bench_result_t base_stl = bench_unary(env, "std::hash", hash_from_std_t {env}).log(base);
 
-#if SZ_USE_HASWELL
+#if SZ_USE_WESTMERE
     bench_unary(
-        env, "sz_hash_stream_haswell", validator,
-        hash_stream_from_sz<sz_hash_state_init_haswell, sz_hash_state_update_haswell, sz_hash_state_digest_haswell> {
+        env, "sz_hash_stream_westmere", validator,
+        hash_stream_from_sz<sz_hash_state_init_westmere, sz_hash_state_update_westmere, sz_hash_state_digest_westmere> {
             env})
         .log(base, base_stl);
 #endif

--- a/scripts/test_stringzilla.cpp
+++ b/scripts/test_stringzilla.cpp
@@ -352,13 +352,13 @@ void test_equivalence() {
     assert(sz_hash_serial("abc", 3, 100) != sz_hash_serial("abc", 3, 200));
     assert(sz_hash_serial("abcdefgh", 8, 0) != sz_hash_serial("abcdefgh", 8, 7));
 
-#if SZ_USE_HASWELL
+#if SZ_USE_WESTMERE
     test_hash_equivalence(                                        //
         sz_hash_serial, sz_hash_state_init_serial,                //
         sz_hash_state_update_serial, sz_hash_state_digest_serial, //
-        sz_hash_haswell, sz_hash_state_init_haswell,              //
-        sz_hash_state_update_haswell, sz_hash_state_digest_haswell);
-    test_random_generator_equivalence(sz_fill_random_serial, sz_fill_random_haswell);
+        sz_hash_westmere, sz_hash_state_init_westmere,            //
+        sz_hash_state_update_westmere, sz_hash_state_digest_westmere);
+    test_random_generator_equivalence(sz_fill_random_serial, sz_fill_random_westmere);
 #endif
 #if SZ_USE_SKYLAKE
     test_hash_equivalence(                                        //

--- a/scripts/test_stringzilla.cpp
+++ b/scripts/test_stringzilla.cpp
@@ -24,6 +24,7 @@
  *  ! but they come handy during development, if you want to validate
  *  ! different ISA-specific implementations.
 
+ #define SZ_USE_NEHALEM 0
  #define SZ_USE_HASWELL 0
  #define SZ_USE_SKYLAKE 0
  #define SZ_USE_ICE 0
@@ -2004,6 +2005,7 @@ int main(int argc, char const **argv) {
     // Let's greet the user nicely
     sz_unused_(argc && argv);
     std::printf("Hi, dear tester! You look nice today!\n");
+    std::printf("- Uses Nehalem: %s \n", SZ_USE_NEHALEM ? "yes" : "no");
     std::printf("- Uses Haswell: %s \n", SZ_USE_HASWELL ? "yes" : "no");
     std::printf("- Uses Skylake: %s \n", SZ_USE_SKYLAKE ? "yes" : "no");
     std::printf("- Uses Ice Lake: %s \n", SZ_USE_ICE ? "yes" : "no");

--- a/scripts/test_stringzilla.cpp
+++ b/scripts/test_stringzilla.cpp
@@ -24,7 +24,7 @@
  *  ! but they come handy during development, if you want to validate
  *  ! different ISA-specific implementations.
 
- #define SZ_USE_NEHALEM 0
+ #define SZ_USE_WESTMERE 0
  #define SZ_USE_HASWELL 0
  #define SZ_USE_SKYLAKE 0
  #define SZ_USE_ICE 0
@@ -2005,7 +2005,7 @@ int main(int argc, char const **argv) {
     // Let's greet the user nicely
     sz_unused_(argc && argv);
     std::printf("Hi, dear tester! You look nice today!\n");
-    std::printf("- Uses Nehalem: %s \n", SZ_USE_NEHALEM ? "yes" : "no");
+    std::printf("- Uses Westmere: %s \n", SZ_USE_WESTMERE ? "yes" : "no");
     std::printf("- Uses Haswell: %s \n", SZ_USE_HASWELL ? "yes" : "no");
     std::printf("- Uses Skylake: %s \n", SZ_USE_SKYLAKE ? "yes" : "no");
     std::printf("- Uses Ice Lake: %s \n", SZ_USE_ICE ? "yes" : "no");

--- a/scripts/test_stringzillas.cpp
+++ b/scripts/test_stringzillas.cpp
@@ -15,6 +15,7 @@
 
 #define SZ_USE_NEON 0
 #define SZ_USE_SVE 0
+#define SZ_USE_NEHALEM 0
 #define SZ_USE_HASWELL 0
 #define SZ_USE_SKYLAKE 0
 #define SZ_USE_ICE 0

--- a/scripts/test_stringzillas.cpp
+++ b/scripts/test_stringzillas.cpp
@@ -15,7 +15,7 @@
 
 #define SZ_USE_NEON 0
 #define SZ_USE_SVE 0
-#define SZ_USE_NEHALEM 0
+#define SZ_USE_WESTMERE 0
 #define SZ_USE_HASWELL 0
 #define SZ_USE_SKYLAKE 0
 #define SZ_USE_ICE 0

--- a/scripts/test_stringzillas.cu
+++ b/scripts/test_stringzillas.cu
@@ -15,6 +15,7 @@
 
 #define SZ_USE_NEON 0
 #define SZ_USE_SVE 0
+#define SZ_USE_NEHALEM 0
 #define SZ_USE_HASWELL 0
 #define SZ_USE_SKYLAKE 0
 #define SZ_USE_ICE 0

--- a/scripts/test_stringzillas.cu
+++ b/scripts/test_stringzillas.cu
@@ -15,7 +15,7 @@
 
 #define SZ_USE_NEON 0
 #define SZ_USE_SVE 0
-#define SZ_USE_NEHALEM 0
+#define SZ_USE_WESTMERE 0
 #define SZ_USE_HASWELL 0
 #define SZ_USE_SKYLAKE 0
 #define SZ_USE_ICE 0

--- a/scripts/test_stringzillas.cuh
+++ b/scripts/test_stringzillas.cuh
@@ -26,7 +26,7 @@ using namespace stringzilla;
 using namespace stringzilla::scripts;
 
 int log_environment() {
-    std::printf("- Uses Nehalem: %s \n", SZ_USE_NEHALEM ? "yes" : "no");
+    std::printf("- Uses Westmere: %s \n", SZ_USE_WESTMERE ? "yes" : "no");
     std::printf("- Uses Haswell: %s \n", SZ_USE_HASWELL ? "yes" : "no");
     std::printf("- Uses Skylake: %s \n", SZ_USE_SKYLAKE ? "yes" : "no");
     std::printf("- Uses Ice Lake: %s \n", SZ_USE_ICE ? "yes" : "no");

--- a/scripts/test_stringzillas.cuh
+++ b/scripts/test_stringzillas.cuh
@@ -26,6 +26,7 @@ using namespace stringzilla;
 using namespace stringzilla::scripts;
 
 int log_environment() {
+    std::printf("- Uses Nehalem: %s \n", SZ_USE_NEHALEM ? "yes" : "no");
     std::printf("- Uses Haswell: %s \n", SZ_USE_HASWELL ? "yes" : "no");
     std::printf("- Uses Skylake: %s \n", SZ_USE_SKYLAKE ? "yes" : "no");
     std::printf("- Uses Ice Lake: %s \n", SZ_USE_ICE ? "yes" : "no");

--- a/setup.py
+++ b/setup.py
@@ -241,7 +241,7 @@ def linux_settings(use_cpp: bool = False) -> Tuple[List[str], List[str], List[Tu
         ("SZ_IS_BIG_ENDIAN_", "1" if is_big_endian() else "0"),
         ("SZ_IS_64BIT_X86_", "1" if is_64bit_x86() else "0"),
         ("SZ_IS_64BIT_ARM_", "1" if is_64bit_arm() else "0"),
-        ("SZ_USE_NEHALEM", "1" if is_64bit_x86() else "0"),
+        ("SZ_USE_WESTMERE", "1" if is_64bit_x86() else "0"),
         ("SZ_USE_HASWELL", "1" if is_64bit_x86() else "0"),
         ("SZ_USE_SKYLAKE", "1" if is_64bit_x86() else "0"),
         ("SZ_USE_ICE", "1" if is_64bit_x86() else "0"),
@@ -291,12 +291,12 @@ def darwin_settings(use_cpp: bool = False) -> Tuple[List[str], List[str], List[T
     ]
 
     # We only support single-arch macOS wheels, but not the Universal builds:
-    # - x86_64: enable Nehalem (SSE4.2) and Haswell (AVX2) only
+    # - x86_64: enable Westmere (SSE4.2) and Haswell (AVX2) only
     # - arm64: enable NEON only
     macros_args = [
         ("SZ_IS_64BIT_X86_", "1" if is_64bit_x86() else "0"),
         ("SZ_IS_64BIT_ARM_", "1" if is_64bit_arm() else "0"),
-        ("SZ_USE_NEHALEM", "1" if not is_64bit_arm() and is_64bit_x86() else "0"),
+        ("SZ_USE_WESTMERE", "1" if not is_64bit_arm() and is_64bit_x86() else "0"),
         ("SZ_USE_HASWELL", "1" if not is_64bit_arm() and is_64bit_x86() else "0"),
         ("SZ_USE_SKYLAKE", "0"),
         ("SZ_USE_ICE", "0"),
@@ -326,7 +326,7 @@ def windows_settings(use_cpp: bool = False) -> Tuple[List[str], List[str], List[
         ("SZ_IS_BIG_ENDIAN_", "1" if is_big_endian() else "0"),
         ("SZ_IS_64BIT_X86_", "1" if is_64bit_x86() else "0"),
         ("SZ_IS_64BIT_ARM_", "1" if is_64bit_arm() else "0"),
-        ("SZ_USE_NEHALEM", "1" if is_64bit_x86() else "0"),
+        ("SZ_USE_WESTMERE", "1" if is_64bit_x86() else "0"),
         ("SZ_USE_HASWELL", "1" if is_64bit_x86() else "0"),
         ("SZ_USE_SKYLAKE", "1" if is_64bit_x86() else "0"),
         ("SZ_USE_ICE", "1" if is_64bit_x86() else "0"),

--- a/setup.py
+++ b/setup.py
@@ -241,6 +241,7 @@ def linux_settings(use_cpp: bool = False) -> Tuple[List[str], List[str], List[Tu
         ("SZ_IS_BIG_ENDIAN_", "1" if is_big_endian() else "0"),
         ("SZ_IS_64BIT_X86_", "1" if is_64bit_x86() else "0"),
         ("SZ_IS_64BIT_ARM_", "1" if is_64bit_arm() else "0"),
+        ("SZ_USE_NEHALEM", "1" if is_64bit_x86() else "0"),
         ("SZ_USE_HASWELL", "1" if is_64bit_x86() else "0"),
         ("SZ_USE_SKYLAKE", "1" if is_64bit_x86() else "0"),
         ("SZ_USE_ICE", "1" if is_64bit_x86() else "0"),
@@ -290,11 +291,12 @@ def darwin_settings(use_cpp: bool = False) -> Tuple[List[str], List[str], List[T
     ]
 
     # We only support single-arch macOS wheels, but not the Universal builds:
-    # - x86_64: enable Haswell (AVX2) only
+    # - x86_64: enable Nehalem (SSE4.2) and Haswell (AVX2) only
     # - arm64: enable NEON only
     macros_args = [
         ("SZ_IS_64BIT_X86_", "1" if is_64bit_x86() else "0"),
         ("SZ_IS_64BIT_ARM_", "1" if is_64bit_arm() else "0"),
+        ("SZ_USE_NEHALEM", "1" if not is_64bit_arm() and is_64bit_x86() else "0"),
         ("SZ_USE_HASWELL", "1" if not is_64bit_arm() and is_64bit_x86() else "0"),
         ("SZ_USE_SKYLAKE", "0"),
         ("SZ_USE_ICE", "0"),
@@ -324,6 +326,7 @@ def windows_settings(use_cpp: bool = False) -> Tuple[List[str], List[str], List[
         ("SZ_IS_BIG_ENDIAN_", "1" if is_big_endian() else "0"),
         ("SZ_IS_64BIT_X86_", "1" if is_64bit_x86() else "0"),
         ("SZ_IS_64BIT_ARM_", "1" if is_64bit_arm() else "0"),
+        ("SZ_USE_NEHALEM", "1" if is_64bit_x86() else "0"),
         ("SZ_USE_HASWELL", "1" if is_64bit_x86() else "0"),
         ("SZ_USE_SKYLAKE", "1" if is_64bit_x86() else "0"),
         ("SZ_USE_ICE", "1" if is_64bit_x86() else "0"),


### PR DESCRIPTION
Thanks to @Algunenano and the broader ClickHouse team for help, back-porting StringZilla kernels to older CPUs 🤗 
With this release:

- Substring search and hashing on CPUs from Westmere to Haswell will become at least 2x faster.
- Inferring Skylake capabilities in dynamic dispatch won't require `VAES` extensions only needed for Ice Lake and newer.
- MSVC will correctly detect Haswell, Ice Lake, and NEON capabilities for compile-time dispatch, lacking options to differentiate other platforms from macros.