### PR TITLE
Fixed windows deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -659,42 +659,40 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [x64, x86]
+        include:
+          - arch: x64
+            target: x64
     steps:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
           ref: "main"
           submodules: recursive
-
-      - name: Setup CMake
-        uses: jwlawson/actions-setup-cmake@v1.13
-
-      - name: Setup MinGW
-        uses: egor-tensin/setup-mingw@v2
+        
+      - uses: ilammy/msvc-dev-cmd@v1
         with:
-          platform: ${{ matrix.arch }}
-          version: 12.2.0
+          arch: ${{ matrix.arch }}
 
       - name: Get version
         id: set_version
-        shell: bash
+        shell: cmd
         run: |
-          version=$(cat VERSION)
-          echo "version=$version" >> $GITHUB_OUTPUT
+          set /p version=<VERSION
+          echo version=%version% >> %GITHUB_OUTPUT%
 
       - name: Build library
+        shell: cmd
         run: |
           cmake -DCMAKE_BUILD_TYPE=Release -B build_release -DSTRINGZILLA_BUILD_SHARED=1
           cmake --build build_release --config Release
-          tar -cvf "stringzilla_bare_windows_${{ matrix.arch }}_${{ steps.set_version.outputs.version }}.tar" "build_release/stringzilla_bare.dll" "build_release/stringzilla_bare.lib" "./include/stringzilla/stringzilla.h"
+          tar -cvf "stringzilla_bare_windows_${{ matrix.target }}_${{ steps.set_version.outputs.version }}.tar" "build_release\stringzilla_bare.dll" "build_release\stringzilla_bare.lib" ".\include\stringzilla\stringzilla.h"
 
       - name: Upload archive
         uses: xresloader/upload-to-github-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          file: "stringzilla_bare_windows_${{ matrix.arch }}_${{ steps.set_version.outputs.version }}.tar"
+          file: "stringzilla_bare_windows_${{ matrix.target }}_${{ steps.set_version.outputs.version }}.tar"
           update_latest_release: true
 
   create_macos_library:


### PR DESCRIPTION
Changed the windows deploy script to use msvc-dev-cmd instead of mingw. Because for some reason the mingw/cmake with Visual Studio generator puts the .lib file into a sub folder.
I removed the x86 deployment because it was actually building a x64 binary, and there currently is no x86 build tests for windows.
This change will also make it easier to add future architectures for deployment.