### PR TITLE
Use GPU registers more effectively

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -177,8 +177,16 @@
       "cwd": "${workspaceFolder}",
       "environment": [
         {
+          "name": "STRINGWARS_STRESS",
+          "value": "0"
+        },
+        {
+          "name": "STRINGWARS_FILTER",
+          "value": "levenshtein_cuda:batch64"
+        },
+        {
           "name": "STRINGWARS_DATASET",
-          "value": "leipzig1M.txt"
+          "value": "acgt_100.txt"
         }
       ],
       "stopAtEntry": false,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -702,7 +702,6 @@ function (define_stringzillas_shared target source_file backend_flags)
     target_include_directories(${target} PRIVATE fork_union/include)
     target_compile_definitions(${target} PRIVATE "SZ_DYNAMIC_DISPATCH=1")
     target_compile_definitions(${target} PRIVATE "SZ_AVOID_LIBC=0")
-    target_compile_definitions(${target} PRIVATE "SZ_DEBUG=0")
 
     # Set backend-specific compilation flags
     foreach (flag ${backend_flags})

--- a/include/stringzillas/similarities.cuh
+++ b/include/stringzillas/similarities.cuh
@@ -2259,7 +2259,7 @@ template < //
     sz_capability_t capability_ = sz_cap_cuda_k,                                     //
     unsigned max_text_length_ = levenshtein_on_each_cuda_thread_default_text_limit_k //
     >
-__global__ __launch_bounds__(128, 4)           // Target: 128 threads/block, 4 blocks/SM for occupancy
+__global__ __launch_bounds__(256, 4)           // Target: 256 threads/block, 4 blocks/SM minimum
     void levenshtein_on_each_cuda_thread_(     //
         task_type_ *tasks, size_t tasks_count, //
         uniform_substitution_costs_t const substituter, linear_gap_costs_t const gap_costs) {
@@ -2442,9 +2442,9 @@ struct levenshtein_distances<char_type_, gap_costs_type_, allocator_type_, capab
                 thread_level_kernel_args[2] = (void *)(&substituter_);
                 thread_level_kernel_args[3] = (void *)(&gap_costs_);
 
-                // Launch configuration tuned for register-heavy kernel with __launch_bounds__(128, 4)
-                unsigned const threads_per_block = 128;
-                unsigned const blocks_per_multiprocessor = 16; // Aggressive: H100 can handle high block count
+                // Launch configuration tuned for register-heavy kernel with __launch_bounds__(256, 4)
+                unsigned const threads_per_block = 256;
+                unsigned const blocks_per_multiprocessor = 8; // 2048 threads/SM = 256 × 8
                 unsigned const total_blocks = blocks_per_multiprocessor * specs.streaming_multiprocessors;
                 cudaError_t launch_error = cudaLaunchKernel(       //
                     reinterpret_cast<void *>(thread_level_kernel), // Kernel function pointer

--- a/scripts/bench_similarities.cuh
+++ b/scripts/bench_similarities.cuh
@@ -112,9 +112,9 @@ void bench_levenshtein(environment_t const &env) {
     sz_unused_(scramble_accelerated_results);
 
     // Let's define some weird scoring schemes for Levenshtein-like distance, that are not unary:
-    constexpr linear_gap_costs_t weird_linear {3};
+    constexpr linear_gap_costs_t weird_linear {2};
     constexpr affine_gap_costs_t weird_affine {4, 2};
-    constexpr uniform_substitution_costs_t weird_uniform {1, 3};
+    constexpr uniform_substitution_costs_t weird_uniform {1, 2};
 
     for (std::size_t batch_size : batch_sizes) {
         results_linear_baseline.resize(batch_size), results_linear_accelerated.resize(batch_size);

--- a/scripts/test_similarities.cuh
+++ b/scripts/test_similarities.cuh
@@ -34,21 +34,24 @@ inline std::size_t levenshtein_baseline(                                //
     std::vector<std::size_t> matrix_buffer(rows * cols);
 
     // Initialize the borders of the matrix.
-    for (std::size_t i = 0; i < rows; ++i) matrix_buffer[i * cols + 0] /* [i][0] in 2D */ = i * gap_cost;
-    for (std::size_t j = 0; j < cols; ++j) matrix_buffer[0 * cols + j] /* [0][j] in 2D */ = j * gap_cost;
+    for (std::size_t row = 0; row < rows; ++row) matrix_buffer[row * cols + 0] /* [row][0] in 2D */ = row * gap_cost;
+    for (std::size_t col = 0; col < cols; ++col) matrix_buffer[0 * cols + col] /* [0][col] in 2D */ = col * gap_cost;
 
-    for (std::size_t i = 1; i < rows; ++i) {
-        std::size_t const *last_row = &matrix_buffer[(i - 1) * cols];
-        std::size_t *row = &matrix_buffer[i * cols];
-        for (std::size_t j = 1; j < cols; ++j) {
-            std::size_t substitution_cost = (s1[i - 1] == s2[j - 1]) ? match_cost : mismatch_cost;
-            std::size_t if_deletion_or_insertion = std::min(last_row[j], row[j - 1]) + gap_cost;
-            row[j] = std::min(if_deletion_or_insertion, last_row[j - 1] + substitution_cost);
+    for (std::size_t row = 1; row < rows; ++row) {
+        std::size_t const *last_row_buffer = &matrix_buffer[(row - 1) * cols];
+        std::size_t *current_row_buffer = &matrix_buffer[row * cols];
+        for (std::size_t col = 1; col < cols; ++col) {
+            std::size_t substitution_cost = (s1[row - 1] == s2[col - 1]) ? match_cost : mismatch_cost;
+            std::size_t if_deletion_or_insertion =
+                std::min(last_row_buffer[col], current_row_buffer[col - 1]) + gap_cost;
+            current_row_buffer[col] = std::min(if_deletion_or_insertion, last_row_buffer[col - 1] + substitution_cost);
         }
     }
 
     return matrix_buffer.back();
 }
+
+#if 0 // ! Coming later :)
 
 /**
  *  The purpose of this class is to emulate SIMD processing in CUDA with 4-byte-wide words,
@@ -169,6 +172,8 @@ inline std::size_t levenshtein_recursive_baseline(                      //
 
     return algorithm(s1_padded, s2_padded, match_cost, mismatch_cost, gap_cost, previous, current, next);
 }
+
+#endif // ! Coming later :)
 
 /**
  *  @brief Inefficient baseline Needleman-Wunsch alignment score computation, as implemented in most codebases.


### PR DESCRIPTION
All of our algorithms on GPU extensively leverage shared memory and warp-level synchronization. That might be suboptimal for very small input sizes. There, we should keep everything in the registers.

So I'm suggesting a new set of kernels processing the DP matrix row-by-row, but keep only one row and one scalar in GPU registers. Moreover, it process the matrix of `uint8_t` cells in slices of 4 continuous entries forming `uint32_t`-s in each row. That minimizes the number of loads & stores, conversions between 8-bit and 32-bit representations - assuming GPUs don't have much custom logic for 8-bit times and upcast practically every time.