### PR TITLE
When compiling with c++23 modules, there is a warning about the use o…

### DIFF
--- a/include/stringzilla/types.h
+++ b/include/stringzilla/types.h
@@ -153,23 +153,30 @@
  *  - `SZ_DYNAMIC` is used for functions that are part of the public API, but are dispatched at runtime.
  *  - `SZ_EXTERNAL` is used for third-party libraries that are linked dynamically.
  */
+
+#if defined(__cplusplus)
+#define SZ_C_INLINE inline
+#else
+#define SZ_C_INLINE inline static
+#endif
+
 #if SZ_DYNAMIC_DISPATCH
 #if defined(_WIN32) || defined(__CYGWIN__)
 #define SZ_DYNAMIC __declspec(dllexport)
 #define SZ_EXTERNAL __declspec(dllimport)
-#define SZ_PUBLIC inline static
-#define SZ_INTERNAL inline static
+#define SZ_PUBLIC SZ_C_INLINE
+#define SZ_INTERNAL SZ_C_INLINE
 #else
 #define SZ_DYNAMIC extern __attribute__((visibility("default")))
 #define SZ_EXTERNAL extern
-#define SZ_PUBLIC __attribute__((unused)) inline static
-#define SZ_INTERNAL __attribute__((always_inline)) inline static
+#define SZ_PUBLIC __attribute__((unused)) SZ_C_INLINE
+#define SZ_INTERNAL __attribute__((always_inline)) SZ_C_INLINE
 #endif // _WIN32 || __CYGWIN__
 #else
-#define SZ_DYNAMIC inline static
+#define SZ_DYNAMIC SZ_C_INLINE
 #define SZ_EXTERNAL extern
-#define SZ_PUBLIC inline static
-#define SZ_INTERNAL inline static
+#define SZ_PUBLIC SZ_C_INLINE
+#define SZ_INTERNAL SZ_C_INLINE
 #endif // SZ_DYNAMIC_DISPATCH
 
 /**


### PR DESCRIPTION
When compiling with c++23 modules, there is a warning about the use of the function qualifier `inline static`.

The fix just detects the presence of a c++ compiler and uses `inline` instead of `inline static` as a function prefix. This issue is almost identical to the following issue in another project:
https://github.com/ocornut/imgui/issues/8682

Here is a quote of the reasoning about whether or not static is necessary in c++.
> You do not need static. In C you need static inline for functions in headers because C did not have the behavior of the one-definition-rule (ODR) like C++. Here static just meant each translation unit got internal linkage of such a function. In C++, you do not get internal linkage with just inline, but ODR permits you to have many copies of the same function across translation units.
> Likewise, template functions and auto functions are implicitly inline (linkage) in C++ too, so if you have those in headers you can also omit the inline keyword (unless you want to hint the optimizer) Though I see many prefer to write it out anyways.
> [...]
> Maybe another way of looking at it is that in C++ non-template inline functions are implicitly static, so they have internal linkage by default, which explains why using static or using inline is sufficient and not both are required.
> But the internal linkage here is really different from C's internal linkage since these are actually globally weak references and the linker just throws out all but one.
> True internal linkage in C++ (like C) is really only possible with explicit static and/or anonymous namespaces from what I gather.