### PR TITLE
Improve: Reduce startup overhead for `sz_find_byteset_haswell`

### DIFF
--- a/include/stringzilla/find.h
+++ b/include/stringzilla/find.h
@@ -1132,12 +1132,13 @@ SZ_PUBLIC sz_cptr_t sz_find_byteset_haswell(sz_cptr_t text, sz_size_t length, sz
 
     // Let's unzip even and odd elements and replicate them into both lanes of the YMM register.
     // That way when we invoke `_mm256_shuffle_epi8` we can use the same mask for both lanes.
+    // Load the 32-byte filter as two 16-byte halves, separate even/odd bytes, pack, and broadcast to YMM.
+    sz_u128_vec_t byte_mask_vec;
+    sz_u128_vec_t filter_lo_vec, filter_hi_vec;
+    sz_u128_vec_t lo_evens_vec, hi_evens_vec;
+    sz_u128_vec_t lo_odds_vec, hi_odds_vec;
+    sz_u128_vec_t evens_xmm_vec, odds_xmm_vec;
     sz_u256_vec_t filter_even_vec, filter_odd_vec;
-    sz_u128_vec_t filter_mask;
-    sz_u128_vec_t filter_lo, filter_hi;
-    sz_u128_vec_t filter_lo_even, filter_hi_even;
-    sz_u128_vec_t filter_lo_odd, filter_hi_odd;
-    sz_u128_vec_t filter_even, filter_odd;
 
     sz_u256_vec_t text_vec;
     sz_u256_vec_t matches_vec;
@@ -1145,19 +1146,19 @@ SZ_PUBLIC sz_cptr_t sz_find_byteset_haswell(sz_cptr_t text, sz_size_t length, sz
     sz_u256_vec_t bitset_even_vec, bitset_odd_vec;
     sz_u256_vec_t bitmask_vec, bitmask_lookup_vec;
 
-    filter_mask.xmm = _mm_set1_epi16(0x00ff);
+    byte_mask_vec.xmm = _mm_set1_epi16(0x00ff);
 
-    filter_lo.xmm = _mm_lddqu_si128((__m128i const *)(filter));
-    filter_hi.xmm = _mm_lddqu_si128((__m128i const *)(filter) + 1);
-    filter_lo_even.xmm = _mm_and_si128(filter_lo.xmm, filter_mask.xmm);
-    filter_hi_even.xmm = _mm_and_si128(filter_hi.xmm, filter_mask.xmm);
-    filter_lo_odd.xmm = _mm_srli_epi16(filter_lo.xmm, 8);
-    filter_hi_odd.xmm = _mm_srli_epi16(filter_hi.xmm, 8);
+    filter_lo_vec.xmm = _mm_lddqu_si128((__m128i const *)(filter));
+    filter_hi_vec.xmm = _mm_lddqu_si128((__m128i const *)(filter) + 1);
+    lo_evens_vec.xmm = _mm_and_si128(filter_lo_vec.xmm, byte_mask_vec.xmm);
+    hi_evens_vec.xmm = _mm_and_si128(filter_hi_vec.xmm, byte_mask_vec.xmm);
+    lo_odds_vec.xmm = _mm_srli_epi16(filter_lo_vec.xmm, 8);
+    hi_odds_vec.xmm = _mm_srli_epi16(filter_hi_vec.xmm, 8);
 
-    filter_even.xmm = _mm_packus_epi16(filter_lo_even.xmm, filter_hi_even.xmm);
-    filter_odd.xmm = _mm_packus_epi16(filter_lo_odd.xmm, filter_hi_odd.xmm);
-    filter_even_vec.ymm = _mm256_set_m128i(filter_even.xmm, filter_even.xmm);
-    filter_odd_vec.ymm = _mm256_set_m128i(filter_odd.xmm, filter_odd.xmm);
+    evens_xmm_vec.xmm = _mm_packus_epi16(lo_evens_vec.xmm, hi_evens_vec.xmm);
+    odds_xmm_vec.xmm = _mm_packus_epi16(lo_odds_vec.xmm, hi_odds_vec.xmm);
+    filter_even_vec.ymm = _mm256_set_m128i(evens_xmm_vec.xmm, evens_xmm_vec.xmm);
+    filter_odd_vec.ymm = _mm256_set_m128i(odds_xmm_vec.xmm, odds_xmm_vec.xmm);
 
     bitmask_lookup_vec.ymm = _mm256_set_epi8(                       //
         -128, 64, 32, 16, 8, 4, 2, 1, -128, 64, 32, 16, 8, 4, 2, 1, //


### PR DESCRIPTION
The current unzip implementation uses a union-based conversion:

https://github.com/ashvardanian/StringZilla/blob/682d2ba4345820d597d3cbf6a7ca86b564e248c5/include/stringzilla/find.h#L1131-L1139

Clang (20/19/18...) generates a massive dependency chain of `vpinsrb` instructions for this pattern:

```cpp
// -O3 -march=znver3
auto test_find_byteset(const char *str, size_t len, const sz_byteset_t *bs) {
    return sz_find_byteset(str, len, bs);
}

0000000000000000 <test_find_byteset(char const*, unsigned long, sz_byteset_t const*)>:
       0:      	movq	%rdi, %rax
       3:      	cmpq	$0x20, %rsi
       7:      	jb	 <L0>
       d:      	movzbl	(%rdx), %ecx
      10:      	movzbl	0x1(%rdx), %edi
      14:      	vbroadcastss	, %ymm2 <test_find_byteset(char const*, unsigned long, sz_byteset_t const*)+0x1d>
      1d:      	vpbroadcastq	, %ymm3 <test_find_byteset(char const*, unsigned long, sz_byteset_t const*)+0x26>
      26:      	vpbroadcastb	, %ymm4 <test_find_byteset(char const*, unsigned long, sz_byteset_t const*)+0x2f>
      2f:      	vpxor	%xmm5, %xmm5, %xmm5
      33:      	vmovd	%ecx, %xmm0
      37:      	vpinsrb	$0x1, 0x2(%rdx), %xmm0, %xmm0 👈
      3e:      	vmovd	%edi, %xmm1
      42:      	vpinsrb	$0x1, 0x3(%rdx), %xmm1, %xmm1
      49:      	vpinsrb	$0x2, 0x4(%rdx), %xmm0, %xmm0 👈
      50:      	vpinsrb	$0x2, 0x5(%rdx), %xmm1, %xmm1
      57:      	vpinsrb	$0x3, 0x6(%rdx), %xmm0, %xmm0 👈
      5e:      	vpinsrb	$0x3, 0x7(%rdx), %xmm1, %xmm1
      65:      	vpinsrb	$0x4, 0x8(%rdx), %xmm0, %xmm0 👈
      6c:      	vpinsrb	$0x4, 0x9(%rdx), %xmm1, %xmm1
      73:      	vpinsrb	$0x5, 0xa(%rdx), %xmm0, %xmm0
      7a:      	vpinsrb	$0x5, 0xb(%rdx), %xmm1, %xmm1
      81:      	vpinsrb	$0x6, 0xc(%rdx), %xmm0, %xmm0
      88:      	vpinsrb	$0x6, 0xd(%rdx), %xmm1, %xmm1
      8f:      	vpinsrb	$0x7, 0xe(%rdx), %xmm0, %xmm0
      96:      	vpinsrb	$0x7, 0xf(%rdx), %xmm1, %xmm1
      9d:      	vpinsrb	$0x8, 0x10(%rdx), %xmm0, %xmm0
      a4:      	vpinsrb	$0x8, 0x11(%rdx), %xmm1, %xmm1
      ab:      	vpinsrb	$0x9, 0x12(%rdx), %xmm0, %xmm0
      b2:      	vpinsrb	$0x9, 0x13(%rdx), %xmm1, %xmm1
      b9:      	vpinsrb	$0xa, 0x14(%rdx), %xmm0, %xmm0
      c0:      	vpinsrb	$0xa, 0x15(%rdx), %xmm1, %xmm1
      c7:      	vpinsrb	$0xb, 0x16(%rdx), %xmm0, %xmm0
      ce:      	vpinsrb	$0xb, 0x17(%rdx), %xmm1, %xmm1
      d5:      	vpinsrb	$0xc, 0x18(%rdx), %xmm0, %xmm0
      dc:      	vpinsrb	$0xc, 0x19(%rdx), %xmm1, %xmm1
      e3:      	vpinsrb	$0xd, 0x1a(%rdx), %xmm0, %xmm0
      ea:      	vpinsrb	$0xd, 0x1b(%rdx), %xmm1, %xmm1
      f1:      	vpinsrb	$0xe, 0x1c(%rdx), %xmm0, %xmm0
      f8:      	vpinsrb	$0xe, 0x1d(%rdx), %xmm1, %xmm1
      ff:      	vpinsrb	$0xf, 0x1e(%rdx), %xmm0, %xmm0
     106:      	vpinsrb	$0xf, 0x1f(%rdx), %xmm1, %xmm1
     10d:      	vpermq	$0x44, %ymm0, %ymm0     # ymm0 = ymm0[0,1,0,1]
     113:      	vpermq	$0x44, %ymm1, %ymm1     # ymm1 = ymm1[0,1,0,1]
     119:      	nopl	(%rax)
<L2>:
     120:      	vlddqu	(%rax), %ymm6
     ...
```

This patch rewrites the unzip logic, which is basically "copied" from the GCC-14 assembly codegen. See https://godbolt.org/z/eb7xe5Pr9

Benchmarks were run on a Zen 3 device. I didn't change the core algorithm, but it just looks much better for almost every case:

```
Clang-20
| Dataset / Mode      | main-haswell      | patch-haswell   | Improvement |
|---------------------|-------------------|-----------------|-------------|
| Words (5B avg)      | 285.45 MiB/s      | 347.74 MiB/s    | +21.8%      |
| Lines (128B avg)    | 2.70 GiB/s        | 3.32 GiB/s      | +23.0%      |
| File (4KB)          | 9.58 GiB/s        | 10.19 GiB/s     | +6.4%       |
| File (16KB)         | 12.48 GiB/s       | 12.97 GiB/s     | +3.9%       |
| File (64KB)         | 11.98 GiB/s       | 12.34 GiB/s     | +3.0%       |
| File (64MB)         | 6.26 GiB/s        | 7.50 GiB/s      | +19.8%      |

GCC-14
| Dataset / Mode      | main-haswell      | patch-haswell   | Improvement |
|---------------------|-------------------|-----------------|-------------|
| Words (5B avg)      | 374.76 MiB/s      | 362.27 MiB/s    | -3.3%       |
| Lines (128B avg)    | 3.07 GiB/s        | 3.44 GiB/s      | +12.0%      |
| File (4KB)          | 7.89 GiB/s        | 11.16 GiB/s     | +41.4%      |
| File (16KB)         | 10.25 GiB/s       | 14.27 GiB/s     | +39.2%      |
| File (64KB)         | 9.75 GiB/s        | 13.73 GiB/s     | +40.8%      |
| File (64MB)         | 6.02 GiB/s        | 7.73 GiB/s      | +28.4%      |
```

Benchmark scripts:

```bash
for s in 4k 16k 64k; do head -c $s leipzig1M.txt > leipzig1M_${s}.txt; done

bench() {
    rm -rf build_release
    cmake -DSTRINGZILLA_BUILD_BENCHMARK=1 -B build_release
    cmake --build build_release --config Release --target stringzilla_bench_find_cpp20
    export STRINGWARS_FILTER="(sz_find_byteset_serial|sz_find_byteset_haswell)"
    CMD="setarch $(uname -m) -R ./build_release/stringzilla_bench_find_cpp20"

    STRINGWARS_TOKENS=words $CMD
    STRINGWARS_TOKENS=lines $CMD
    for s in 4k 16k 64k; do STRINGWARS_TOKENS=file STRINGWARS_DATASET=leipzig1M_${s}.txt $CMD; done
    STRINGWARS_TOKENS=file $CMD
}

# `byteset-haswell` refers to this patch.
for branch in main byteset-haswell; do
    git switch $branch
    echo -e "\n=== Testing Clang ($branch) ==="
    export CC=clang-20 CXX=clang++-20; bench
    echo -e "\n=== Testing GCC ($branch) ==="
    export CC=gcc-14 CXX=g++-14; bench
done

rm leipzig1M_*
```

(I also tried another full-MM256 implementation using permute4x64, but it was slightly slower (~2%) than this patch.)
