### PR TITLE
Add CI tests for free-threaded Python build

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1256,7 +1256,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, macos-15, windows-2022, windows-11-arm]
-        python-version: ["310", "311", "312", "313", "314"]
+        python-version: ["310", "311", "312", "313", "314", "314t"]
         exclude:
           - os: windows-11-arm
             python-version: "310"

--- a/build_backend.py
+++ b/build_backend.py
@@ -190,7 +190,11 @@ def cli_run_tests(project_dir: Optional[str] = None) -> None:
             str(proj / "test" / "similarities.py"),
             str(proj / "test" / "fingerprints.py"),
         ]
-    subprocess.check_call([sys.executable, "-m", "pytest", "-s", "-x", *tests])  # noqa: S603
+    # A data race only shows on a free-threaded interpreter, and only if the suite runs concurrently.
+    # Doctests sit out: they assert against a process-wide stdout capture that concurrent threads interleave.
+    gil_enabled = getattr(sys, "_is_gil_enabled", lambda: True)()
+    parallel = [] if gil_enabled else ["--parallel-threads=4", "--ignore=" + str(proj / "test" / "doctests.py")]
+    subprocess.check_call([sys.executable, "-m", "pytest", "-s", "-x", *parallel, *tests])  # noqa: S603
 
 
 def cli_check_wheels(wheel_dir: str, required: List[str]) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ line-length = 120
 before-test = ["python {project}/build_backend.py pull-deps {project}"]
 build-verbosity = 0
 test-command = "python {project}/build_backend.py run-tests {project}"
-test-requires = ["pytest", "pytest-repeat"]
+test-requires = ["pytest", "pytest-repeat", "pytest-run-parallel"]
 
 # We need to build for all platforms:
 # - on Linux: x86_64, aarch64, i686, ppc64le, s390x


### PR DESCRIPTION
This modifies the "prerelease" workflow so that it builds and tests with Python 3.14t.  The tests are run using pytest-run-parallel, which makes it more likely that thread safety issues are found.  

Note that I only added CI testing for the Ubuntu-Arm/GCC/Python-3.14t combo.  Testing the full matrix of combinations is overkill, IMHO.

See https://github.com/ashvardanian/StringZilla/issues/296 for the tracking issue for this feature.