### PR TITLE
[RFC] Break down the static library into multiple files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -613,7 +613,18 @@ target_include_directories(
 
 # Helper function used for `stringzilla_shared` and `stringzilla_bare` targets
 function (define_stringzilla_shared target)
-    add_library(${target} SHARED c/stringzilla.c)
+    add_library(${target} SHARED
+        c/compare.c
+        c/memory.c
+        c/find.c
+        c/hash.c
+        c/utf8.c
+        c/utf8_case.c
+        c/utf8_word.c
+        c/sort.c
+        c/intersect.c
+        c/stringzilla.c
+    )
     add_library(${PROJECT_NAME}::${target} ALIAS ${target})
 
     set_target_properties(

--- a/c/compare.c
+++ b/c/compare.c
@@ -1,0 +1,27 @@
+/**
+*   @file       compare.c
+ *  @brief      StringZilla compare functions compiled into library
+ *  @author     Raul Marin
+ *  @date       February 5, 2026
+ */
+
+#ifdef SZ_DYNAMIC_DISPATCH
+#undef SZ_DYNAMIC_DISPATCH
+#endif
+#define SZ_DYNAMIC_DISPATCH 0
+
+// Include types.h first to let it define the macros
+#include <stringzilla/types.h>
+
+// Use weak symbols to allow multiple definitions (linker will merge them)
+#undef SZ_PUBLIC
+#undef SZ_C_INLINE
+#undef SZ_INTERNAL
+#define SZ_C_INLINE __attribute__((weak))
+#define SZ_PUBLIC __attribute__((weak))
+#define SZ_INTERNAL static inline
+#undef SZ_DYNAMIC
+#define SZ_DYNAMIC static inline
+
+// Now include compare.h which will use our overridden macros
+#include <stringzilla/compare.h>

--- a/c/find.c
+++ b/c/find.c
@@ -1,0 +1,27 @@
+/**
+ *  @file       find.c
+ *  @brief      StringZilla find functions compiled into library
+ *  @author     Raul Marin
+ *  @date       February 5, 2026
+ */
+
+#ifdef SZ_DYNAMIC_DISPATCH
+#undef SZ_DYNAMIC_DISPATCH
+#endif
+#define SZ_DYNAMIC_DISPATCH 0
+
+// Include types.h first to let it define the macros
+#include <stringzilla/types.h>
+
+// Now override the macros AFTER types.h has defined them
+#undef SZ_PUBLIC
+#undef SZ_C_INLINE
+#undef SZ_INTERNAL
+// Use weak symbols to allow multiple definitions (linker will merge them)
+#define SZ_C_INLINE __attribute__((weak))
+#define SZ_PUBLIC __attribute__((weak))
+#define SZ_INTERNAL static inline
+#undef SZ_DYNAMIC
+#define SZ_DYNAMIC static inline
+
+#include <stringzilla/find.h>

--- a/c/hash.c
+++ b/c/hash.c
@@ -1,0 +1,27 @@
+/**
+ *  @file       hash.c
+ *  @brief      StringZilla hash functions compiled into library
+ *  @author     Raul Marin
+ *  @date       February 5, 2026
+ */
+
+#ifdef SZ_DYNAMIC_DISPATCH
+#undef SZ_DYNAMIC_DISPATCH
+#endif
+#define SZ_DYNAMIC_DISPATCH 0
+
+// Include types.h first to let it define the macros
+#include <stringzilla/types.h>
+
+// Use weak symbols to allow multiple definitions (linker will merge them)
+#undef SZ_PUBLIC
+#undef SZ_C_INLINE
+#undef SZ_INTERNAL
+#define SZ_C_INLINE __attribute__((weak))
+#define SZ_PUBLIC __attribute__((weak))
+#define SZ_INTERNAL static inline
+#undef SZ_DYNAMIC
+#define SZ_DYNAMIC static inline
+
+
+#include <stringzilla/hash.h>

--- a/c/intersect.c
+++ b/c/intersect.c
@@ -1,0 +1,27 @@
+/**
+ *  @file       intersect.c
+ *  @brief      StringZilla intersect functions compiled into library
+ *  @author     Raul Marin
+ *  @date       February 5, 2026
+ */
+
+#ifdef SZ_DYNAMIC_DISPATCH
+#undef SZ_DYNAMIC_DISPATCH
+#endif
+#define SZ_DYNAMIC_DISPATCH 0
+
+// Include types.h first to let it define the macros
+#include <stringzilla/types.h>
+
+// Use weak symbols to allow multiple definitions (linker will merge them)
+#undef SZ_PUBLIC
+#undef SZ_C_INLINE
+#undef SZ_INTERNAL
+#define SZ_C_INLINE __attribute__((weak))
+#define SZ_PUBLIC __attribute__((weak))
+#define SZ_INTERNAL static inline
+#undef SZ_DYNAMIC
+#define SZ_DYNAMIC static inline
+
+
+#include <stringzilla/intersect.h>

--- a/c/memory.c
+++ b/c/memory.c
@@ -1,0 +1,27 @@
+/**
+ *  @file       memory.c
+ *  @brief      StringZilla memory functions compiled into library
+ *  @author     Raul Marin
+ *  @date       February 5, 2026
+ */
+
+#ifdef SZ_DYNAMIC_DISPATCH
+#undef SZ_DYNAMIC_DISPATCH
+#endif
+#define SZ_DYNAMIC_DISPATCH 0
+
+// Include types.h first to let it define the macros
+#include <stringzilla/types.h>
+
+// Use weak symbols to allow multiple definitions (linker will merge them)
+#undef SZ_PUBLIC
+#undef SZ_C_INLINE
+#undef SZ_INTERNAL
+#define SZ_C_INLINE __attribute__((weak))
+#define SZ_PUBLIC __attribute__((weak))
+#define SZ_INTERNAL static inline
+#undef SZ_DYNAMIC
+#define SZ_DYNAMIC static inline
+
+
+#include <stringzilla/memory.h>

--- a/c/sort.c
+++ b/c/sort.c
@@ -1,0 +1,27 @@
+/**
+ *  @file       sort.c
+ *  @brief      StringZilla sort functions compiled into library
+ *  @author     Raul Marin
+ *  @date       February 5, 2026
+ */
+
+#ifdef SZ_DYNAMIC_DISPATCH
+#undef SZ_DYNAMIC_DISPATCH
+#endif
+#define SZ_DYNAMIC_DISPATCH 0
+
+// Include types.h first to let it define the macros
+#include <stringzilla/types.h>
+
+// Use weak symbols to allow multiple definitions (linker will merge them)
+#undef SZ_PUBLIC
+#undef SZ_C_INLINE
+#undef SZ_INTERNAL
+#define SZ_C_INLINE __attribute__((weak))
+#define SZ_PUBLIC __attribute__((weak))
+#define SZ_INTERNAL static inline
+#undef SZ_DYNAMIC
+#define SZ_DYNAMIC static inline
+
+
+#include <stringzilla/sort.h>

--- a/c/utf8.c
+++ b/c/utf8.c
@@ -1,0 +1,27 @@
+/**
+ *  @file       utf8.c
+ *  @brief      StringZilla UTF-8 functions compiled into library
+ *  @author     Raul Marin
+ *  @date       February 5, 2026
+ */
+
+#ifdef SZ_DYNAMIC_DISPATCH
+#undef SZ_DYNAMIC_DISPATCH
+#endif
+#define SZ_DYNAMIC_DISPATCH 0
+
+// Include types.h first to let it define the macros
+#include <stringzilla/types.h>
+
+// Use weak symbols to allow multiple definitions (linker will merge them)
+#undef SZ_PUBLIC
+#undef SZ_C_INLINE
+#undef SZ_INTERNAL
+#define SZ_C_INLINE __attribute__((weak))
+#define SZ_PUBLIC __attribute__((weak))
+#define SZ_INTERNAL static inline
+#undef SZ_DYNAMIC
+#define SZ_DYNAMIC static inline
+
+
+#include <stringzilla/utf8.h>

--- a/c/utf8_case.c
+++ b/c/utf8_case.c
@@ -1,0 +1,27 @@
+/**
+ *  @file       utf8_case.c
+ *  @brief      StringZilla UTF-8 case functions compiled into library
+ *  @author     Raul Marin
+ *  @date       February 5, 2026
+ */
+
+#ifdef SZ_DYNAMIC_DISPATCH
+#undef SZ_DYNAMIC_DISPATCH
+#endif
+#define SZ_DYNAMIC_DISPATCH 0
+
+// Include types.h first to let it define the macros
+#include <stringzilla/types.h>
+
+// Now override the macros AFTER types.h has defined them
+#undef SZ_PUBLIC
+#undef SZ_C_INLINE
+#undef SZ_INTERNAL
+// Use weak symbols to allow multiple definitions (linker will merge them)
+#define SZ_C_INLINE __attribute__((weak))
+#define SZ_PUBLIC __attribute__((weak))
+#define SZ_INTERNAL static inline
+#undef SZ_DYNAMIC
+#define SZ_DYNAMIC static inline
+
+#include <stringzilla/utf8_case.h>

--- a/c/utf8_word.c
+++ b/c/utf8_word.c
@@ -1,0 +1,27 @@
+/**
+ *  @file       utf8_word.c
+ *  @brief      StringZilla UTF-8 word functions compiled into library
+ *  @author     Raul Marin
+ *  @date       February 5, 2026
+ */
+
+#ifdef SZ_DYNAMIC_DISPATCH
+#undef SZ_DYNAMIC_DISPATCH
+#endif
+#define SZ_DYNAMIC_DISPATCH 0
+
+// Include types.h first to let it define the macros
+#include <stringzilla/types.h>
+
+// Use weak symbols to allow multiple definitions (linker will merge them)
+#undef SZ_PUBLIC
+#undef SZ_C_INLINE
+#undef SZ_INTERNAL
+#define SZ_C_INLINE __attribute__((weak))
+#define SZ_PUBLIC __attribute__((weak))
+#define SZ_INTERNAL static inline
+#undef SZ_DYNAMIC
+#define SZ_DYNAMIC static inline
+
+
+#include <stringzilla/utf8_word.h>

--- a/include/stringzilla/compare.h
+++ b/include/stringzilla/compare.h
@@ -120,6 +120,8 @@ SZ_PUBLIC sz_ordering_t sz_order_neon(sz_cptr_t a, sz_size_t a_length, sz_cptr_t
 
 #pragma endregion // Core API
 
+#if !SZ_DYNAMIC_DISPATCH
+
 /* SSE implementation of the string search algorithms for Westmere processors and newer.
  *  Very minimalistic (compared to AVX-512), but still faster than the serial implementation.
  */
@@ -516,7 +518,6 @@ SZ_PUBLIC sz_ordering_t sz_order_sve(sz_cptr_t a, sz_size_t a_length, sz_cptr_t 
  *  To override this behavior and precompile all backends - set `SZ_DYNAMIC_DISPATCH` to 1.
  */
 #pragma region Compile Time Dispatching
-#if !SZ_DYNAMIC_DISPATCH
 
 SZ_DYNAMIC sz_bool_t sz_equal(sz_cptr_t a, sz_cptr_t b, sz_size_t length) {
 #if SZ_USE_SKYLAKE
@@ -546,8 +547,9 @@ SZ_DYNAMIC sz_ordering_t sz_order(sz_cptr_t a, sz_size_t a_length, sz_cptr_t b, 
 #endif
 }
 
-#endif            // !SZ_DYNAMIC_DISPATCH
 #pragma endregion // Compile Time Dispatching
+
+#endif            // !SZ_DYNAMIC_DISPATCH
 
 #ifdef __cplusplus
 }

--- a/include/stringzilla/find.h
+++ b/include/stringzilla/find.h
@@ -240,6 +240,8 @@ SZ_PUBLIC sz_cptr_t sz_find_delimiters_utf8_ice(sz_cptr_t text, sz_size_t length
 SZ_PUBLIC sz_cptr_t sz_find_delimiters_utf8_neon(sz_cptr_t text, sz_size_t length, sz_size_t *matched_length);
 #endif
 
+#if !SZ_DYNAMIC_DISPATCH
+
 #pragma endregion // Core API
 
 #pragma region Helper Shortcuts
@@ -2005,7 +2007,6 @@ SZ_PUBLIC sz_cptr_t sz_find_sve(sz_cptr_t h, sz_size_t h_length, sz_cptr_t n, sz
  *  To override this behavior and precompile all backends - set `SZ_DYNAMIC_DISPATCH` to 1.
  */
 #pragma region Compile Time Dispatching
-#if !SZ_DYNAMIC_DISPATCH
 
 #pragma region Core Functionality
 
@@ -2096,8 +2097,9 @@ SZ_DYNAMIC sz_cptr_t sz_rfind_byteset(sz_cptr_t text, sz_size_t length, sz_bytes
 }
 
 #pragma endregion
-#endif            // !SZ_DYNAMIC_DISPATCH
 #pragma endregion // Compile Time Dispatching
+
+#endif            // !SZ_DYNAMIC_DISPATCH
 
 #ifdef __cplusplus
 }

--- a/include/stringzilla/hash.h
+++ b/include/stringzilla/hash.h
@@ -323,6 +323,15 @@ SZ_PUBLIC void sz_sha256_state_update_goldmont(sz_sha256_state_t *state, sz_cptr
 /** @copydoc sz_sha256_state_digest */
 SZ_PUBLIC void sz_sha256_state_digest_goldmont(sz_sha256_state_t const *state, sz_u8_t digest[sz_at_least_(32)]);
 
+/** @copydoc sz_sha256_state_init */
+SZ_PUBLIC void sz_sha256_state_init_serial(sz_sha256_state_t *state);
+
+/** @copydoc sz_sha256_state_update */
+SZ_PUBLIC void sz_sha256_state_update_serial(sz_sha256_state_t *state, sz_cptr_t text, sz_size_t length);
+
+/** @copydoc sz_sha256_state_digest */
+SZ_PUBLIC void sz_sha256_state_digest_serial(sz_sha256_state_t const *state, sz_u8_t digest[sz_at_least_(32)]);
+
 #endif
 
 #if SZ_USE_HASWELL
@@ -458,6 +467,8 @@ SZ_PUBLIC sz_u64_t sz_hash_state_digest_sve2(sz_hash_state_t const *state);
 #endif
 
 #pragma endregion // Core API
+
+#if !SZ_DYNAMIC_DISPATCH
 
 #pragma region Helper Methods
 
@@ -4151,7 +4162,6 @@ SZ_PUBLIC void sz_fill_random_sve2(sz_ptr_t text, sz_size_t length, sz_u64_t non
  *  To override this behavior and precompile all backends - set `SZ_DYNAMIC_DISPATCH` to 1.
  */
 #pragma region Compile Time Dispatching
-#if !SZ_DYNAMIC_DISPATCH
 
 SZ_DYNAMIC sz_u64_t sz_bytesum(sz_cptr_t text, sz_size_t length) {
 #if SZ_USE_ICE
@@ -4287,8 +4297,9 @@ SZ_DYNAMIC void sz_sha256_state_digest(sz_sha256_state_t const *state, sz_u8_t d
 #endif
 }
 
-#endif            // !SZ_DYNAMIC_DISPATCH
 #pragma endregion // Compile Time Dispatching
+
+#endif            // !SZ_DYNAMIC_DISPATCH
 
 #ifdef __cplusplus
 }

--- a/include/stringzilla/intersect.h
+++ b/include/stringzilla/intersect.h
@@ -229,6 +229,11 @@ typedef enum {
     sz_join_cross_k = 5,
 } sz_sequence_join_semantics_t;
 
+SZ_PUBLIC sz_status_t sz_sequence_intersect_serial(                                 //
+    sz_sequence_t const *first_sequence, sz_sequence_t const *second_sequence,      //
+    sz_memory_allocator_t *alloc, sz_u64_t seed, sz_size_t *intersection_count_ptr, //
+    sz_sorted_idx_t *first_positions, sz_sorted_idx_t *second_positions);
+
 #if SZ_USE_ICE
 
 /** @copydoc sz_sequence_intersect */
@@ -250,6 +255,8 @@ SZ_PUBLIC sz_status_t sz_sequence_intersect_sve(                               /
 #endif
 
 #pragma endregion
+
+#if !SZ_DYNAMIC_DISPATCH
 
 #pragma region Serial Implementation
 
@@ -766,7 +773,6 @@ SZ_PUBLIC sz_status_t sz_sequence_intersect_sve(sz_sequence_t const *first_seque
  *  To override this behavior and precompile all backends - set `SZ_DYNAMIC_DISPATCH` to 1.
  */
 #pragma region Compile Time Dispatching
-#if !SZ_DYNAMIC_DISPATCH
 
 SZ_DYNAMIC sz_status_t sz_sequence_intersect(sz_sequence_t const *first_sequence, sz_sequence_t const *second_sequence,
                                              sz_memory_allocator_t *alloc, sz_u64_t seed, sz_size_t *intersection_size,
@@ -789,8 +795,9 @@ SZ_DYNAMIC sz_status_t sz_sequence_intersect(sz_sequence_t const *first_sequence
 #endif
 }
 
-#endif            // !SZ_DYNAMIC_DISPATCH
 #pragma endregion // Compile Time Dispatching
+
+#endif            // !SZ_DYNAMIC_DISPATCH
 
 #ifdef __cplusplus
 }

--- a/include/stringzilla/memory.h
+++ b/include/stringzilla/memory.h
@@ -196,6 +196,8 @@ SZ_PUBLIC void sz_lookup_neon(sz_ptr_t target, sz_size_t length, sz_cptr_t sourc
 
 #pragma endregion // Core API
 
+#if !SZ_DYNAMIC_DISPATCH
+
 #pragma region Helper API
 
 /**
@@ -1423,7 +1425,6 @@ SZ_PUBLIC void sz_lookup_sve(sz_ptr_t target, sz_size_t length, sz_cptr_t source
  *  To override this behavior and precompile all backends - set `SZ_DYNAMIC_DISPATCH` to 1.
  */
 #pragma region Compile Time Dispatching
-#if !SZ_DYNAMIC_DISPATCH
 
 #pragma region Core Functionality
 
@@ -1483,8 +1484,9 @@ SZ_DYNAMIC void sz_lookup(sz_ptr_t target, sz_size_t length, sz_cptr_t source, c
 #endif
 }
 
-#endif            // !SZ_DYNAMIC_DISPATCH
 #pragma endregion // Compile Time Dispatching
+
+#endif            // !SZ_DYNAMIC_DISPATCH
 
 #ifdef __cplusplus
 }

--- a/include/stringzilla/sort.h
+++ b/include/stringzilla/sort.h
@@ -344,6 +344,8 @@ SZ_INTERNAL void sz_sequence_sorting_network_8x_(sz_pgram_t *pgrams, sz_sorted_i
 
 #pragma endregion // Generic Internal Helpers
 
+#if !SZ_DYNAMIC_DISPATCH
+
 #pragma region Serial QuickSort Implementation
 
 SZ_INTERNAL void sz_sequence_argsort_serial_export_next_pgrams_(                //
@@ -1167,7 +1169,6 @@ SZ_PUBLIC sz_status_t sz_sequence_argsort_sve(sz_sequence_t const *sequence, sz_
  *  To override this behavior and precompile all backends - set `SZ_DYNAMIC_DISPATCH` to 1.
  */
 #pragma region Compile Time Dispatching
-#if !SZ_DYNAMIC_DISPATCH
 
 SZ_DYNAMIC sz_status_t sz_sequence_argsort(sz_sequence_t const *sequence, sz_memory_allocator_t *alloc,
                                            sz_sorted_idx_t *order) {
@@ -1191,8 +1192,9 @@ SZ_DYNAMIC sz_status_t sz_pgrams_sort(sz_pgram_t *pgrams, sz_size_t count, sz_me
 #endif
 }
 
-#endif            // !SZ_DYNAMIC_DISPATCH
 #pragma endregion // Compile Time Dispatching
+
+#endif            // !SZ_DYNAMIC_DISPATCH
 
 #ifdef __cplusplus
 }

--- a/include/stringzilla/utf8.h
+++ b/include/stringzilla/utf8.h
@@ -267,6 +267,8 @@ SZ_PUBLIC sz_cptr_t sz_utf8_find_whitespace_sve2(sz_cptr_t text, sz_size_t lengt
 
 #pragma endregion
 
+#if !SZ_DYNAMIC_DISPATCH
+
 /*  Implementation Section
  *  Following the same pattern as find.h with implementations in the header file.
  */
@@ -1734,8 +1736,6 @@ SZ_PUBLIC sz_cptr_t sz_utf8_find_whitespace_sve2(sz_cptr_t text, sz_size_t lengt
 
 #pragma region Dynamic Dispatch
 
-#if !SZ_DYNAMIC_DISPATCH
-
 SZ_DYNAMIC sz_size_t sz_utf8_count(sz_cptr_t text, sz_size_t length) {
 #if SZ_USE_ICE
     return sz_utf8_count_ice(text, length);
@@ -1792,9 +1792,9 @@ SZ_DYNAMIC sz_cptr_t sz_utf8_find_whitespace(sz_cptr_t text, sz_size_t length, s
 #endif
 }
 
-#endif // !SZ_DYNAMIC_DISPATCH
-
 #pragma endregion // Dynamic Dispatch
+
+#endif // !SZ_DYNAMIC_DISPATCH
 
 #ifdef __cplusplus
 }

--- a/include/stringzilla/utf8_case.h
+++ b/include/stringzilla/utf8_case.h
@@ -364,6 +364,8 @@ SZ_PUBLIC sz_bool_t sz_utf8_case_invariant_neon(sz_cptr_t str, sz_size_t length)
 
 #pragma endregion
 
+#if !SZ_DYNAMIC_DISPATCH
+
 /*  Implementation Section
  *  Following the same pattern as find.h with implementations in the header file.
  */
@@ -8386,8 +8388,6 @@ SZ_PUBLIC sz_bool_t sz_utf8_case_invariant_neon(sz_cptr_t str, sz_size_t length)
 
 #pragma region Dynamic Dispatch
 
-#if !SZ_DYNAMIC_DISPATCH
-
 SZ_DYNAMIC sz_cptr_t sz_utf8_unpack_chunk(sz_cptr_t text, sz_size_t length, sz_rune_t *runes, sz_size_t runes_capacity,
                                           sz_size_t *runes_unpacked) {
 #if SZ_USE_ICE
@@ -8431,9 +8431,9 @@ SZ_DYNAMIC sz_bool_t sz_utf8_case_invariant(sz_cptr_t str, sz_size_t length) {
 #endif
 }
 
-#endif // !SZ_DYNAMIC_DISPATCH
-
 #pragma endregion // Dynamic Dispatch
+
+#endif // !SZ_DYNAMIC_DISPATCH
 
 #ifdef __cplusplus
 }

--- a/include/stringzilla/utf8_word.h
+++ b/include/stringzilla/utf8_word.h
@@ -132,6 +132,8 @@ SZ_PUBLIC sz_cptr_t sz_utf8_word_rfind_boundary_ice(sz_cptr_t text, sz_size_t le
 
 #pragma endregion
 
+#if !SZ_DYNAMIC_DISPATCH
+
 /*  Implementation Section
  *  Following the same pattern as find.h with implementations in the header file.
  */
@@ -1129,7 +1131,6 @@ SZ_PUBLIC sz_cptr_t sz_utf8_word_rfind_boundary_serial(sz_cptr_t text, sz_size_t
  *  When dynamic dispatch is disabled, the SZ_DYNAMIC functions simply forward to serial implementations.
  *  When dynamic dispatch is enabled, these are provided by the shared library.
  */
-#if !SZ_DYNAMIC_DISPATCH
 
 SZ_DYNAMIC sz_cptr_t sz_utf8_word_find_boundary(sz_cptr_t text, sz_size_t length, sz_size_t *boundary_width) {
     return sz_utf8_word_find_boundary_serial(text, length, boundary_width);
@@ -1139,9 +1140,9 @@ SZ_DYNAMIC sz_cptr_t sz_utf8_word_rfind_boundary(sz_cptr_t text, sz_size_t lengt
     return sz_utf8_word_rfind_boundary_serial(text, length, boundary_width);
 }
 
-#endif // !SZ_DYNAMIC_DISPATCH
-
 #pragma endregion // Dynamic Dispatch
+
+#endif // !SZ_DYNAMIC_DISPATCH
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
After updating ClickHouse to 4.6.0 we've noticed that `stringzilla.c` has become a bottleneck in the build, as it takes from ~90 (release) to ~150 (asan) seconds to build. The problem is that it builds all the functions in a single translation unit, and compiling and specially optimizing it takes quite a bit of time.

Instead we could separate the functions into different files and build them independently and in parallel. Doing it this way reduces the build time to the slowest file (`utf8_case.c`, around 3 seconds with ASAN):

```
/mnt/ch/ClickHouse/contrib/StringZilla/c/compare.c

real    0m0.295s
user    0m0.275s
sys     0m0.019s
/mnt/ch/ClickHouse/contrib/StringZilla/c/find.c

real    0m0.708s
user    0m0.674s
sys     0m0.031s
/mnt/ch/ClickHouse/contrib/StringZilla/c/hash.c

real    0m1.023s
user    0m0.963s
sys     0m0.054s
/mnt/ch/ClickHouse/contrib/StringZilla/c/intersect.c

real    0m2.192s
user    0m2.130s
sys     0m0.049s
/mnt/ch/ClickHouse/contrib/StringZilla/c/memory.c

real    0m1.043s
user    0m1.002s
sys     0m0.035s
/mnt/ch/ClickHouse/contrib/StringZilla/c/sort.c

real    0m1.368s
user    0m1.321s
sys     0m0.040s
/mnt/ch/ClickHouse/contrib/StringZilla/c/stringzilla.c

real    0m0.209s
user    0m0.184s
sys     0m0.024s
/mnt/ch/ClickHouse/contrib/StringZilla/c/utf8.c

real    0m0.353s
user    0m0.326s
sys     0m0.025s
/mnt/ch/ClickHouse/contrib/StringZilla/c/utf8_case.c

real    0m3.025s
user    0m2.891s
sys     0m0.108s
/mnt/ch/ClickHouse/contrib/StringZilla/c/utf8_word.c

real    0m0.223s
user    0m0.195s
```

To implement this each file includes a single header and redefines the macros to expose the symbols in the translation unit (built `SZ_DYNAMIC_DISPATCH=0`) and in the headers we hide the implementation when building with `SZ_DYNAMIC_DISPATCH=1`, so `stringzilla.c` only sees the function definitions.

I had to fight with the LLM to get it to do what I needed, so for transparency here is its [summary](https://pastila.nl/?0001c58d/c4be11f55f88fffa199bccb00a101211#AOVadklLKblHl4YlJY8ZlQ==GCM).

Note that I've only tested this with Linux and clang so far. It's likely that other platforms would need a different approach.