### PR TITLE
To `-O3` or not to `-O3`, that is the question!

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -27,7 +27,7 @@ fn build_stringzilla() -> HashMap<String, bool> {
         .define("SZ_DYNAMIC_DISPATCH", "1")
         .define("SZ_AVOID_LIBC", "0")
         .define("SZ_DEBUG", "0")
-        .flag("-O2")
+        .flag("-O3")
         .flag("-std=c99") // Enforce C99 standard
         .flag_if_supported("-fdiagnostics-color=always")
         .flag_if_supported("-fPIC");
@@ -162,7 +162,7 @@ fn build_stringzillas(serial_flags: &HashMap<String, bool>) {
         .define("SZ_DYNAMIC_DISPATCH", "1")
         .define("SZ_AVOID_LIBC", "0")
         .define("SZ_DEBUG", "0")
-        .flag("-O2");
+        .flag("-O3");
 
     // Nvidia GPU backend
     if is_cuda {


### PR DESCRIPTION
I am not sure why this is built with -O3 I have tested it both on Neon and AVX endpoints and -O3 on gcc and clang actually gives a measurable impact 