### PR TITLE
Fix OOB read in sz_find_skylake tail for null-byte needles

### DIFF
--- a/include/stringzilla/find.h
+++ b/include/stringzilla/find.h
@@ -1374,6 +1374,7 @@ SZ_PUBLIC sz_cptr_t sz_find_skylake(sz_cptr_t h, sz_size_t h_length, sz_cptr_t n
                 _mm512_cmpeq_epi8_mask(h_first_vec.zmm, n_first_vec.zmm),
                 _mm512_cmpeq_epi8_mask(h_mid_vec.zmm, n_mid_vec.zmm)),
             _mm512_cmpeq_epi8_mask(h_last_vec.zmm, n_last_vec.zmm));
+        matches &= mask;
         while (matches) {
             int potential_offset = sz_u64_ctz(matches);
             if (n_length <= 3 || sz_equal_skylake(h + potential_offset, n, n_length)) return h + potential_offset;
@@ -1456,6 +1457,7 @@ SZ_PUBLIC sz_cptr_t sz_rfind_skylake(sz_cptr_t h, sz_size_t h_length, sz_cptr_t 
                 _mm512_cmpeq_epi8_mask(h_first_vec.zmm, n_first_vec.zmm),
                 _mm512_cmpeq_epi8_mask(h_mid_vec.zmm, n_mid_vec.zmm)),
             _mm512_cmpeq_epi8_mask(h_last_vec.zmm, n_last_vec.zmm));
+        matches &= mask;
         while (matches) {
             int potential_offset = sz_u64_clz(matches);
             if (n_length <= 3 || sz_equal_skylake(h + 64 - potential_offset - 1, n, n_length))

--- a/scripts/test_stringzilla.cpp
+++ b/scripts/test_stringzilla.cpp
@@ -4195,6 +4195,17 @@ void test_search_with_misaligned_repetitions() {
     test_search_with_misaligned_repetitions("abc\0", "abc\0");
     test_search_with_misaligned_repetitions("abcd\0", "abcd");
 
+    // When searching for all-null needles in a haystack with no null bytes.
+    // This exercises the SIMD tail path where masked-off lanes are zeroed:
+    // if the needle characters are also zero, spurious matches appear at
+    // invalid offsets beyond the haystack, causing OOB reads.
+    test_search_with_misaligned_repetitions("a", {"\0\0", 2});
+    test_search_with_misaligned_repetitions("a", {"\0\0\0", 3});
+    test_search_with_misaligned_repetitions("a", {"\0\0\0\0", 4});
+    test_search_with_misaligned_repetitions("a", {"\0\0\0\0\0", 5});
+    test_search_with_misaligned_repetitions("abcd", {"\0\0", 2});
+    test_search_with_misaligned_repetitions("abcd", {"\0\0\0\0", 4});
+
     // When haystack is formed of equidistant needles:
     test_search_with_misaligned_repetitions("ab", "a");
     test_search_with_misaligned_repetitions("abc", "a");


### PR DESCRIPTION
## Bug

The tail section of `sz_find_skylake` and `sz_rfind_skylake` has an out-of-bounds read when the needle consists entirely of null bytes (e.g., `"\0\0\0\0"`).

**Root cause:** Masked loads (`_mm512_maskz_loadu_epi8`) zero out bytes beyond the valid range, but the subsequent `_mm512_cmpeq_epi8_mask` comparisons are unmasked — they compare all 64 lanes. When the needle characters selected by `sz_locate_needle_anomalies_` are all `\0`, the zeroed masked-off lanes falsely match, producing spurious `matches` bits at invalid offsets.

- For `n_length <= 3`: returns an OOB pointer without validation
- For `n_length > 3`: `sz_equal_skylake` reads past the haystack, causing heap-buffer-overflow

Other implementations (serial, westmere, haswell, neon) are unaffected — they fall back to `sz_find_serial` for the tail.

## Fix

AND `matches` with `mask` before the match loop in both `sz_find_skylake` and `sz_rfind_skylake` tails:

```c
matches &= mask;
```

## Reproducer

```c
// Returns offset 9 (OOB) instead of NULL:
sz_find_skylake("AAAAAAAAAA", 10, "\0\0", 2);

// Heap-buffer-overflow under ASan:
char *h = malloc(10);
memset(h, 'A', 10);
sz_find_skylake(h, 10, "\0\0\0\0", 4);
```

All `sz_find_serial`, `sz_find_westmere`, and `sz_find_haswell` correctly return NULL for these inputs.

## Test coverage

Added test cases to `test_search_with_misaligned_repetitions` that search for all-null needles in haystacks containing no null bytes — the only scenario where the spurious masked-off matches are the sole "hits" and the bug becomes observable.

Found via ClickHouse CI AST fuzzer (MSan build):
```sql
SELECT count() FROM system.schema_inference_cache
WHERE toNullable(65537) > countSubstrings(source, '\0\0\0\0')
```