### PR TITLE
fix(find): guard sz_rfind_with_suffix_ against unsigned loop-bound underflow (OOB read)

### DIFF
--- a/include/stringzilla/find.h
+++ b/include/stringzilla/find.h
@@ -808,6 +808,13 @@ SZ_INTERNAL sz_cptr_t sz_rfind_with_suffix_(sz_cptr_t h, sz_size_t h_length, sz_
 
     sz_size_t prefix_length = n_length - suffix_length;
     while (1) {
+        // A partial-suffix match shrinks `h_length` (below) guarded only by the
+        // prefix room; a short tail can then leave fewer than `suffix_length`
+        // bytes for the next `find_suffix`, underflowing its unsigned loop bound
+        // (`i <= h_length - n_length` -> ~2^64) into an out-of-bounds read. Guard
+        // up front, mirroring the forward twin `sz_find_with_prefix_`'s
+        // `remaining < n_length` check.
+        if (h_length < n_length) return SZ_NULL_CHAR;
         sz_cptr_t found = find_suffix(h, h_length, n + prefix_length, suffix_length);
         if (!found) return SZ_NULL_CHAR;
 


### PR DESCRIPTION
## Summary

`sz_rfind_with_suffix_` (the reverse long-needle helper in `find.h`) can perform an **out-of-bounds read** for needles in the 257–511 byte range. Found by a fuzzer under UBSan; reproduces on the unmodified library with two perfectly valid `std::string`s.

## Root cause

For a long needle, reverse search finds a suffix, then verifies the prefix and continues. On a partial match it shrinks the haystack:

```c
// find.h — sz_rfind_with_suffix_
sz_size_t prefix_length = n_length - suffix_length;
while (1) {
    sz_cptr_t found = find_suffix(h, h_length, n + prefix_length, suffix_length);
    if (!found) return SZ_NULL_CHAR;
    sz_size_t remaining = found - h;
    if (remaining < prefix_length) return SZ_NULL_CHAR;   // only checks prefix room
    if (sz_equal_serial(found - prefix_length, n, prefix_length)) return found - prefix_length;
    h_length = remaining - 1;                             // shrinks haystack
}
```

The next iteration calls `find_suffix` again, which needs **`suffix_length`** bytes — but the shrink is guarded only by `remaining < prefix_length`. When `prefix_length < suffix_length` (e.g. a 306 B needle: prefix 50, suffix 256), `h_length` can drop below `suffix_length`. Inside `sz_rfind_horspool_upto_256bytes_serial_` the loop bound

```c
for (sz_size_t j = 0; j <= h_length - n_length; ...)   // n_length here == suffix_length (256)
```

underflows (`h_length - 256` wraps to ~2^64), so `j` ranges to ~2^64 and the body dereferences far out of bounds.

The **forward** twin `sz_find_with_prefix_` guards correctly (`if (remaining < n_length) return SZ_NULL_CHAR;`); only the reverse path is missing the symmetric check. All SIMD backends (`sz_rfind_haswell/skylake/neon`) fall through to this serial helper for the long-needle tail, so the bug bites on **every dispatch path** for needles 257–511 B.

## Fix

One symmetric guard at the top of the loop, mirroring the forward helper — if the (possibly shrunk) haystack can no longer contain the full needle, there is no match:

```c
while (1) {
    if (h_length < n_length) return SZ_NULL_CHAR;
    sz_cptr_t found = find_suffix(h, h_length, n + prefix_length, suffix_length);
    ...
```

Since `n_length = prefix_length + suffix_length >= suffix_length`, this guarantees every `find_suffix` call has enough bytes.

## Reproduction

```cpp
#include <string>
#include <stringzilla/stringzilla.hpp>
namespace sz = ashvardanian::stringzilla;
int main() {
  std::string hay(306, '\xff');
  hay.replace(11, 6, "_``'_`");          // distinct middle => no full match
  std::string needle(306, '\xff');
  sz::string_view h{hay.data(), hay.size()}, n{needle.data(), needle.size()};
  auto pos = h.rfind(n);                  // before: OOB read / segfault; after: npos
  return pos == sz::string_view::npos ? 0 : 1;
}
```

Built with `c/stringzilla.c -DSZ_DYNAMIC_DISPATCH=1`:
- **Before fix:** segfault (OOB read), via both `sz_rfind_serial` directly and the dispatched `sz_rfind`.
- **After fix:** returns `npos`, exit 0, matching `std::string::rfind`.

Verified on x86_64 (clang and gcc) at v4.6.2.