### PR TITLE
fix: heap overflow in `sz_string_reserve` when shrinking

### DIFF
--- a/include/stringzilla/small_string.h
+++ b/include/stringzilla/small_string.h
@@ -181,6 +181,7 @@ SZ_API_COMPTIME sz_ptr_t sz_string_init_length(sz_string_t *string, sz_size_t le
 /**
  *  @brief Doesn't change the contents or the length of the string, but grows the available memory capacity.
  *         This is beneficial, if several insertions are expected, and we want to minimize allocations.
+ *         Reserving less than the current capacity is a harmless no-op, like `std::string::reserve`.
  *
  *  @param string       String to grow.
  *  @param new_capacity The number of characters to reserve space for, including existing ones.
@@ -353,7 +354,9 @@ SZ_API_COMPTIME sz_ptr_t sz_string_reserve(sz_string_t *string, sz_size_t new_ca
     sz_size_t string_space;
     sz_bool_t string_is_external;
     sz_string_unpack(string, &string_start, &string_length, &string_space, &string_is_external);
-    sz_assert_(new_space > string_space && "New space must be larger than current.");
+    // Shrinking is a no-op, matching `std::string::reserve` semantics. Without this check a smaller
+    // `new_capacity` would allocate a smaller buffer and then overflow it with the old contents.
+    if (new_space <= string_space) return string->external.start;
 
     sz_ptr_t new_start = (sz_ptr_t)allocator->allocate(new_space, allocator->handle);
     if (!new_start) return SZ_NULL_CHAR;

--- a/test/string.cpp
+++ b/test/string.cpp
@@ -1521,6 +1521,44 @@ void test_string_constructors_unit() {
     verify(std::equal(strings.begin(), strings.end(), assignments.begin()));
 }
 
+/**
+ *  @brief Validates that shrinking `reserve` calls are harmless no-ops, just like in the STL.
+ *         Regression test: shrinking used to overflow the heap buffer in release builds.
+ */
+void test_string_reserve_unit() {
+    // C API: grow, then shrink - the buffer, length, and contents must stay intact.
+    {
+        sz_memory_allocator_t alloc;
+        sz_memory_allocator_init_default(&alloc);
+
+        sz_string_t str;
+        sz_ptr_t start = sz_string_init_length(&str, 100, &alloc);
+        verify(start != nullptr);
+        std::memset(start, 'a', 100);
+
+        sz_ptr_t grown = sz_string_reserve(&str, 200, &alloc);
+        verify(grown != nullptr);
+        verify(sz_string_length(&str) == 100);
+
+        // Shrinking must be a no-op: same buffer, same length, same contents.
+        sz_ptr_t shrunk = sz_string_reserve(&str, 50, &alloc);
+        verify(shrunk == grown);
+        verify(sz_string_length(&str) == 100);
+        for (sz_size_t i = 0; i != 100; ++i) verify(shrunk[i] == 'a');
+
+        sz_string_free(&str, &alloc);
+    }
+    // C++ API: `sz::string::reserve` shrinking must match `std::string` behavior - keep the contents.
+    {
+        sz::string str(100, 'a');
+        std::size_t const capacity_before = str.capacity();
+        str.reserve(50);
+        verify(str.size() == 100);
+        verify(str.capacity() == capacity_before);
+        verify(str == sz::string(100, 'a'));
+    }
+}
+
 /** @brief Checks for memory leaks in the string class using the `accounting_allocator`. */
 void test_memory_stability_unit(std::size_t length, std::size_t iterations) {
 

--- a/test/stringzilla.cpp
+++ b/test/stringzilla.cpp
@@ -166,6 +166,7 @@ int main(int argc, char const **argv) {
     failures += run_test("test_extensions_updates_unit", test_extensions_updates_unit);
 
     failures += run_test("test_string_constructors_unit", test_string_constructors_unit);
+    failures += run_test("test_string_reserve_unit", test_string_reserve_unit);
     failures += run_test("test_memory_stability_unit(1024)", [] { test_memory_stability_unit(1024); });
     failures += run_test("test_memory_stability_unit(14)", [] { test_memory_stability_unit(14); });
     failures += run_test("test_string_updates_unit", [] { test_string_updates_unit(); }); // ! Defaulted arg

--- a/test/stringzilla.hpp
+++ b/test/stringzilla.hpp
@@ -724,6 +724,7 @@ void test_extensions_reads_unit();
 
 void test_extensions_updates_unit();
 void test_string_constructors_unit();
+void test_string_reserve_unit();
 void test_memory_stability_unit(std::size_t length = 1ull << 10, std::size_t iterations = scale_iterations(100));
 void test_string_updates_unit(std::size_t repetitions = 1024);
 


### PR DESCRIPTION
#### What this is about

`sz_string_reserve` is StringZilla's version of `std::string::reserve`: it pre-allocates memory for a string so that later appends don't have to reallocate. Nothing in its docs says you must only grow it.

#### The bug

If you reserve *less* than the string currently holds, the function allocates the smaller buffer you asked for, but then still copies the whole existing string into it.

Step by step, with a 100-byte string and `reserve(50)`:

1. A new 51-byte buffer is allocated (50 + 1 for the terminator).
2. All 100 bytes of the old string are copied into it.
3. 49 bytes land past the end of the new buffer, in whatever heap memory sits next to it.

In debug builds an assert catches this. In release builds the assert is compiled out, so nothing does. The string is also left believing it is 100 bytes long while its buffer holds 51, so every later operation works with wrong sizes.

Confirmed with ASan, and without any sanitizer using a guard-byte allocator (all 49 bytes past the block overwritten with the string's own content).

#### Isn't this just caller error?

Fair question. But reserving a smaller capacity is legal in the STL: `std::string::reserve` treats it as a no-op, so C++ programmers are trained to assume it's harmless. It also happens naturally, for example when a buffer is reused for a smaller payload. The library clearly knew the case was bad (there's an assert for it), but the protection doesn't exist in release builds, where it matters. One line turns this invisible trap into defined behavior, at zero cost.

#### The fix

One early return: if the requested capacity isn't bigger than the current one, do nothing and return the current buffer. Exactly what `std::string::reserve` does.

#### Testing

- New regression test `test_string_reserve_unit`: grow a string, shrink it, check buffer, length and contents are untouched (C and C++ APIs).
- The test aborts on the unfixed code, passes with the fix.
- Full C++ suite passes.

No perf impact: one comparison in a function that otherwise allocates and copies. Shrinks actually get faster, since they no longer allocate at all.
