### PR TITLE
fix: reject single-pass iterators in `arrow_strings_tape::try_assign`

### DIFF
--- a/include/stringzilla/types.hpp
+++ b/include/stringzilla/types.hpp
@@ -645,6 +645,13 @@ struct arrow_strings_tape {
 
     template <typename strings_iterator_type_>
     status_t try_assign(strings_iterator_type_ first, strings_iterator_type_ last) noexcept {
+        // The range is walked twice - once to measure, once to copy - so single-pass "input"
+        // iterators, like `std::istream_iterator`, would compile but silently copy nothing.
+        static_assert(
+            std::is_base_of<std::forward_iterator_tag,
+                            typename std::iterator_traits<strings_iterator_type_>::iterator_category>::value,
+            "arrow_strings_tape::try_assign needs multi-pass (forward) iterators");
+
         // Deallocate previous memory if allocated
         if (buffer_.data_ && buffer_.size_)
             char_alloc_.deallocate(const_cast<char_t *>(buffer_.data_), buffer_.size_), buffer_ = {};

--- a/test/string.cpp
+++ b/test/string.cpp
@@ -343,6 +343,23 @@ void test_sequence_unit() {
     }
 }
 
+/**
+ *  @brief Validates that `arrow_strings_tape::try_assign` works with multi-pass forward iterators.
+ *         It walks the range twice, once to measure and once to copy, so single-pass input
+ *         iterators like `std::istream_iterator` are rejected at compile time.
+ */
+void test_strings_tape_assign_unit() {
+    sz::arrow_strings_tape<char, std::uint32_t, std::allocator<char>> tape;
+
+    // A forward list can only be walked forward, but any number of times - exactly what `try_assign` needs.
+    std::forward_list<std::string> strings {"alpha", "", "gamma"};
+    verify(tape.try_assign(strings.begin(), strings.end()) == sz::status_t::success_k);
+    verify(tape.size() == 3);
+    verify(sz::string_view(tape[0].data(), tape[0].size()) == "alpha"_sv);
+    verify(tape[1].size() == 0);
+    verify(sz::string_view(tape[2].data(), tape[2].size()) == "gamma"_sv);
+}
+
 #pragma endregion // Sequence
 
 #pragma region Allocator
@@ -1614,23 +1631,6 @@ void test_string_updates_unit(std::size_t repetitions) {
             verify(sz::string_view(stl_string) == sz::string_view(sz_string));
         }
     }
-}
-
-/**
- *  @brief Validates that `arrow_strings_tape::try_assign` works with multi-pass forward iterators.
- *         It walks the range twice - once to measure, once to copy - so single-pass input iterators
- *         like `std::istream_iterator` are now rejected at compile time.
- */
-void test_strings_tape_assign_unit() {
-    sz::arrow_strings_tape<char, std::uint32_t, std::allocator<char>> tape;
-
-    // A forward list can only be walked forward, but any number of times - exactly what `try_assign` needs.
-    std::forward_list<std::string> strings {"alpha", "", "gamma"};
-    verify(tape.try_assign(strings.begin(), strings.end()) == sz::status_t::success_k);
-    verify(tape.size() == 3);
-    verify(sz::string_view(tape[0].data(), tape[0].size()) == "alpha"_sv);
-    verify(tape[1].size() == 0);
-    verify(sz::string_view(tape[2].data(), tape[2].size()) == "gamma"_sv);
 }
 
 #pragma endregion // String Class

--- a/test/string.cpp
+++ b/test/string.cpp
@@ -50,6 +50,7 @@
 #include <cstring> // `std::memcpy`
 
 #include <algorithm>     // `std::transform`
+#include <forward_list>  // `std::forward_list`
 #include <iterator>      // `std::distance`
 #include <map>           // `std::map`
 #include <memory>        // `std::allocator`
@@ -1613,6 +1614,23 @@ void test_string_updates_unit(std::size_t repetitions) {
             verify(sz::string_view(stl_string) == sz::string_view(sz_string));
         }
     }
+}
+
+/**
+ *  @brief Validates that `arrow_strings_tape::try_assign` works with multi-pass forward iterators.
+ *         It walks the range twice - once to measure, once to copy - so single-pass input iterators
+ *         like `std::istream_iterator` are now rejected at compile time.
+ */
+void test_strings_tape_assign_unit() {
+    sz::arrow_strings_tape<char, std::uint32_t, std::allocator<char>> tape;
+
+    // A forward list can only be walked forward, but any number of times - exactly what `try_assign` needs.
+    std::forward_list<std::string> strings {"alpha", "", "gamma"};
+    verify(tape.try_assign(strings.begin(), strings.end()) == sz::status_t::success_k);
+    verify(tape.size() == 3);
+    verify(sz::string_view(tape[0].data(), tape[0].size()) == "alpha"_sv);
+    verify(tape[1].size() == 0);
+    verify(sz::string_view(tape[2].data(), tape[2].size()) == "gamma"_sv);
 }
 
 #pragma endregion // String Class

--- a/test/stringzilla.cpp
+++ b/test/stringzilla.cpp
@@ -169,6 +169,7 @@ int main(int argc, char const **argv) {
     failures += run_test("test_memory_stability_unit(1024)", [] { test_memory_stability_unit(1024); });
     failures += run_test("test_memory_stability_unit(14)", [] { test_memory_stability_unit(14); });
     failures += run_test("test_string_updates_unit", [] { test_string_updates_unit(); }); // ! Defaulted arg
+    failures += run_test("test_strings_tape_assign_unit", test_strings_tape_assign_unit);
 
     failures += run_test("test_compare_unit", test_compare_unit);
     failures += run_test("test_find_unit", test_find_unit);

--- a/test/stringzilla.cpp
+++ b/test/stringzilla.cpp
@@ -128,6 +128,7 @@ int main(int argc, char const **argv) {
 
     failures += run_test("test_arithmetic_unit", test_arithmetic_unit);
     failures += run_test("test_sequence_unit", test_sequence_unit);
+    failures += run_test("test_strings_tape_assign_unit", test_strings_tape_assign_unit);
     failures += run_test("test_allocator_unit", test_allocator_unit);
     failures += run_test("test_byteset_unit", test_byteset_unit);
 
@@ -169,7 +170,6 @@ int main(int argc, char const **argv) {
     failures += run_test("test_memory_stability_unit(1024)", [] { test_memory_stability_unit(1024); });
     failures += run_test("test_memory_stability_unit(14)", [] { test_memory_stability_unit(14); });
     failures += run_test("test_string_updates_unit", [] { test_string_updates_unit(); }); // ! Defaulted arg
-    failures += run_test("test_strings_tape_assign_unit", test_strings_tape_assign_unit);
 
     failures += run_test("test_compare_unit", test_compare_unit);
     failures += run_test("test_find_unit", test_find_unit);

--- a/test/stringzilla.hpp
+++ b/test/stringzilla.hpp
@@ -726,6 +726,7 @@ void test_extensions_updates_unit();
 void test_string_constructors_unit();
 void test_memory_stability_unit(std::size_t length = 1ull << 10, std::size_t iterations = scale_iterations(100));
 void test_string_updates_unit(std::size_t repetitions = 1024);
+void test_strings_tape_assign_unit();
 
 #pragma endregion // String Class and STL Compatibility
 

--- a/test/stringzilla.hpp
+++ b/test/stringzilla.hpp
@@ -638,6 +638,7 @@ using ashvardanian::stringzilla::scripts::scale_iterations;
 
 void test_arithmetic_unit();
 void test_sequence_unit();
+void test_strings_tape_assign_unit();
 void test_allocator_unit();
 void test_byteset_unit();
 
@@ -726,7 +727,6 @@ void test_extensions_updates_unit();
 void test_string_constructors_unit();
 void test_memory_stability_unit(std::size_t length = 1ull << 10, std::size_t iterations = scale_iterations(100));
 void test_string_updates_unit(std::size_t repetitions = 1024);
-void test_strings_tape_assign_unit();
 
 #pragma endregion // String Class and STL Compatibility
 


### PR DESCRIPTION
#### What this is about

`arrow_strings_tape::try_assign` fills the tape from a list of strings provided through C++ iterators. Iterators are how C++ walks over a collection, and they come in two flavors: some can be walked as many times as you want (like a pointer into a vector), and some can be walked only once, because they consume the source as they go (like `std::istream_iterator` reading from a stream).

#### The bug

`try_assign` needs to walk the list twice: once to measure how much memory to allocate, once to copy the strings in. 

Step by step, with a walk-once iterator:
1. First walk: counts and measures everything correctly, but consumes the stream.
2. Second walk: the stream is empty, so nothing gets copied.
3. The tape still believes it holds all the strings the first walk counted, but their positions in memory were never written.
4. Every read through the tape then uses garbage positions and goes out of bounds (ASan-confirmed).

The nasty part: this compiles fine and returns "success". You only find out later, when your data is junk.

#### Isn't this an unusual way to call it?

Yes, feeding a walk-once iterator is rare. This is hardening more than an active vulnerability. But it's not a design choice either: C++ has a long-standing convention that a function declares when it needs to read a range twice. Today the misuse compiles, returns success, and hands back a broken tape. The `static_assert` makes the existing requirement explicit instead of silent.

#### The fix

A `static_assert` in `try_assign` now requires a walk-many-times (forward) iterator. Single-pass iterators fail at compile time with a clear message, instead of corrupting the tape at run time.

#### Testing

- The old `std::istream_iterator` misuse no longer compiles: "arrow_strings_tape::try_assign needs multi-pass (forward) iterators".
- New regression test `test_strings_tape_assign_unit` assigns from a `std::forward_list` (walk-forward, no random access) and checks the strings land correctly, including an empty one.
- Full C++ suite passes, `-Werror` clean.

Zero runtime cost: the check happens at compile time, the compiled code is identical.
