### PR TITLE
Fix: Exclude test package from Python wheels

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,6 +10,5 @@ graft forkunion/include
 graft c
 graft python
 
-include test/stringzilla.py
-include test/stringzillas.py
+recursive-include test *.py
 include bench/*.py

--- a/setup.py
+++ b/setup.py
@@ -909,7 +909,7 @@ setup(
     include_dirs=[],
     setup_requires=[],
     ext_modules=ext_modules,
-    packages=find_packages(),
+    packages=find_packages(exclude=["test", "test.*"]),
     entry_points=entry_points,
     cmdclass=command_class,
     install_requires=install_requires,


### PR DESCRIPTION
The inspected 5.x wheels install a top-level `test` package into site-packages — `stringzilla` 5.1.2 (macOS arm64, manylinux x86_64), `stringzilla` 5.0.0, `stringzillas-cpus` 5.1.2; 4.6.2 did not.

```
$ uvx check-wheel-contents stringzilla-5.1.2-cp314-cp314-macosx_11_0_arm64.whl
W005: Wheel contains common toplevel name in library: test/
```

`packages=find_packages()` used to pick up `cli`; after `cli/` was removed and `test/` became a package (both 2026-06-25), the only `__init__.py` in the tree is `test/__init__.py`, so the same call now returns `['test']` and the inspected wheels carry all 24 test modules. In a clean venv on a Python that ships no stdlib `test` package (python-build-standalone), `import test` resolves to StringZilla's copy; on the Homebrew Python I tried, the stdlib copy wins. `stringzillas-cpus`, which requires `stringzilla` at the same version, carries the same 24 paths.

This excludes `test` from `find_packages()`. `MANIFEST.in` gets `recursive-include test *.py` in place of the two explicit includes (one of which, `test/stringzilla.py`, no longer matches a file), so the sdist is unaffected: skeleton-built sdists over the real tree shape have identical 337-file lists before and after, while the `setup.py` change alone would drop 23 test files from it.
