### PR TITLE
Fix: Avoid unaligned serial memory accesses

### DIFF
--- a/include/stringzilla/memory/serial.h
+++ b/include/stringzilla/memory/serial.h
@@ -45,9 +45,29 @@ SZ_API_COMPTIME void sz_fill_serial(sz_ptr_t target, sz_size_t length, sz_u8_t v
 #pragma optimize("", on)
 #endif
 
+/** @brief Copies eight bytes through aligned scalar objects, preserving overlap-safe load-before-store ordering. */
+SZ_HELPER_AUTO void sz_copy8_serial_(sz_ptr_t target, sz_cptr_t source) {
+    char const first = source[0];
+    char const second = source[1];
+    char const third = source[2];
+    char const fourth = source[3];
+    char const fifth = source[4];
+    char const sixth = source[5];
+    char const seventh = source[6];
+    char const eighth = source[7];
+    target[0] = first;
+    target[1] = second;
+    target[2] = third;
+    target[3] = fourth;
+    target[4] = fifth;
+    target[5] = sixth;
+    target[6] = seventh;
+    target[7] = eighth;
+}
+
 SZ_API_COMPTIME void sz_copy_serial(sz_ptr_t target, sz_cptr_t source, sz_size_t length) {
 #if SZ_USE_MISALIGNED_LOADS
-    while (length >= 8) *(sz_u64_t *)target = *(sz_u64_t const *)source, target += 8, source += 8, length -= 8;
+    while (length >= 8) sz_copy8_serial_(target, source), target += 8, source += 8, length -= 8;
 #endif
     while (length--) *(target++) = *(source++);
 }
@@ -64,7 +84,7 @@ SZ_API_COMPTIME void sz_move_serial(sz_ptr_t target, sz_cptr_t source, sz_size_t
     // but older CPUs may predict and fetch forward-passes better.
     if (target < source || target >= source + length) {
 #if SZ_USE_MISALIGNED_LOADS
-        while (length >= 8) *(sz_u64_t *)target = *(sz_u64_t const *)(source), target += 8, source += 8, length -= 8;
+        while (length >= 8) sz_copy8_serial_(target, source), target += 8, source += 8, length -= 8;
 #endif
         while (length--) *(target++) = *(source++);
     }
@@ -72,7 +92,7 @@ SZ_API_COMPTIME void sz_move_serial(sz_ptr_t target, sz_cptr_t source, sz_size_t
         // Jump to the end and walk backwards.
         target += length, source += length;
 #if SZ_USE_MISALIGNED_LOADS
-        while (length >= 8) *(sz_u64_t *)(target -= 8) = *(sz_u64_t const *)(source -= 8), length -= 8;
+        while (length >= 8) target -= 8, source -= 8, sz_copy8_serial_(target, source), length -= 8;
 #endif
         while (length--) *(--target) = *(--source);
     }

--- a/test/string.cpp
+++ b/test/string.cpp
@@ -29,7 +29,7 @@
  #define SZ_USE_SVE 0
  #define SZ_USE_SVE2 0
  */
-#define SZ_USE_MISALIGNED_LOADS 0
+#define SZ_USE_MISALIGNED_LOADS 1
 #if defined(SZ_DEBUG)
 #undef SZ_DEBUG
 #endif
@@ -175,12 +175,35 @@ static void check_memory_unit_(sz_copy_t copy, sz_move_t move, sz_fill_t fill) {
         verify(target[length] == '#'); // No overwrite past `length`
     }
 
+    // `copy` must support misaligned byte pointers when its SWAR path is enabled. `alignas(8)` makes the one-byte
+    // offsets provably unaligned for the 64-bit transfer, while the literal checks the copied bytes and both guards.
+    {
+        alignas(8) char const source[] = "abcdefghijklmnopq";
+        alignas(8) char target[sizeof(source) + 1];
+        std::memset(target, '#', sizeof(target));
+        copy(target + 1, source + 1, 16);
+        verify(std::memcmp(target + 1, "bcdefghijklmnopq", 16) == 0);
+        verify(target[0] == '#' && target[17] == '#');
+    }
+
     // `move` handles overlapping regions. Shifting "abcdef" left-into-itself by two yields "cdef" at the front.
     {
         char const expected[] = "cdef"; // After moving "cdef" (offset 2, 4 bytes) to offset 0
         char buffer[] = "abcdef";
         move(buffer, buffer + 2, 4);
         verify(std::memcmp(buffer, expected, 4) == 0);
+    }
+
+    // `move` must preserve `memmove` ordering with misaligned 64-bit transfers in either overlap direction.
+    {
+        alignas(8) char buffer[] = "abcdefghijklmnopqrstuvwx";
+        move(buffer + 1, buffer + 3, 16); // Target precedes source: copy forwards.
+        verify(std::memcmp(buffer, "adefghijklmnopqrsrstuvwx", sizeof(buffer)) == 0);
+    }
+    {
+        alignas(8) char buffer[] = "abcdefghijklmnopqrstuvwx";
+        move(buffer + 3, buffer + 1, 16); // Target follows source: copy backwards.
+        verify(std::memcmp(buffer, "abcbcdefghijklmnopqtuvwx", sizeof(buffer)) == 0);
     }
 
     // `fill` writes a known byte across a known span, leaving a guard byte untouched.


### PR DESCRIPTION
Fix: Avoid unaligned serial memory accesses

## Summary

- replace the serial copy and move paths' unaligned `sz_u64_t*` dereferences with an alignment-safe eight-byte transfer helper
- retain load-before-store ordering so overlapping `sz_move_serial` calls work in both directions
- exercise misaligned copy plus forward and backward overlapping moves in the existing C++ memory unit test

Fixes #279.

## Testing

- `SZ_TESTS_FILTER='test_memory_(unit|all|safety)' SZ_TESTS_MULTIPLIER=0.1 SZ_TESTS_SEED=279 /tmp/stringzilla-279-cpp20-ubsan`
- `SZ_TESTS_MULTIPLIER=0.1 SZ_TESTS_SEED=279 /tmp/stringzilla-279-cpp20`
- direct Clang C++11/14/17 compilation of `test/string.cpp`
